### PR TITLE
Support user supplied grids

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.3 (2018-03-28)
 ------------------
 
+* Support user supplied grids (:pr:`7`)
 * Add dask wrappers to the gridder and degridder (:pr:`4`)
 * Add weights to gridder/degridder and remove psf function (:pr:`2`)
 

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -9,9 +9,10 @@ import numpy as np
 
 from ...util.rtd import on_rtd
 
+
 @numba.jit(nopython=True, nogil=True, cache=True)
 def _nb_grid(vis, uvw, flags, weights, ref_wave,
-          convolution_filter, grid):
+             convolution_filter, grid):
     """
     See :func:"~africanus.gridding.simple.gridding._grid" for
     documentation.
@@ -74,10 +75,11 @@ def _nb_grid(vis, uvw, flags, weights, ref_wave,
 
     return grid
 
+
 def _grid(vis, uvw, flags, weights, ref_wave,
-        convolution_filter,
-        nx=1024, ny=1024,
-        grid=None):
+          convolution_filter,
+          nx=1024, ny=1024,
+          grid=None):
     """
     Convolutional gridder which grids visibilities ``vis``
     at the specified ``uvw`` coordinates and
@@ -123,6 +125,7 @@ def _grid(vis, uvw, flags, weights, ref_wave,
 
     return _nb_grid(vis, uvw, flags, weights, ref_wave,
                     convolution_filter, grid)
+
 
 def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
     """
@@ -206,6 +209,7 @@ def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
 
 # jit the functions if this is not RTD otherwise
 # use the private funcs for generating docstrings
+
 
 grid = _grid
 

--- a/tests/test_simple_gridder.py
+++ b/tests/test_simple_gridder.py
@@ -57,6 +57,11 @@ def test_degridder_gridder():
     vis_grid = grid(vis, uvw, flags, weights, ref_wave,
                                         conv_filter, nx, ny)
 
+    # Test that a user supplied grid works
+    vis_grid = grid(vis, uvw, flags, weights, ref_wave,
+                                conv_filter, grid=vis_grid)
+
+
 def test_psf_subtraction():
     """
     Test that we can create the PSF with the gridder.
@@ -73,7 +78,7 @@ def test_psf_subtraction():
     corr = 4
     chan = 16
     rows = 200
-    npix = nx = ny = 257
+    npix = ny = nx = 257
 
     C = 2.99792458e8
     ARCSEC2RAD = 4.8481e-6
@@ -103,14 +108,14 @@ def test_psf_subtraction():
 
     # Compute PSF of (ny*2, nx*2)
     psf_squared = grid(vis, uvw, flags, weights, ref_wave,
-                                        conv_filter, nx*2, ny*2)
+                                        conv_filter, ny*2, nx*2)
 
     # Test that we have gridded something
     assert np.any(psf_squared > 0.0)
     assert np.any(psf > 0.0)
 
     # Extract the centre of the squared PSF
-    centre_vis = psf_squared[:,nx-nx//2:1+nx+nx//2, nx-nx//2:1+nx+nx//2]
+    centre_vis = psf_squared[:,ny-ny//2:1+ny+ny//2, nx-nx//2:1+nx+nx//2]
 
     # Should be the same
     assert np.all(centre_vis == psf)
@@ -150,7 +155,7 @@ def test_dask_degridder_gridder():
 
     conv_filter = convolution_filter(3, 63, "sinc")
 
-    vis_grid = grid(vis, uvw, flags, weights, ref_wave, conv_filter, nx, ny)
+    vis_grid = grid(vis, uvw, flags, weights, ref_wave, conv_filter, ny, nx)
 
     degrid_vis = degrid(vis_grid, uvw, weights, ref_wave, conv_filter)
 


### PR DESCRIPTION
The `grid` function now optionally supports taking a user-supplied grid.

This allows the gridder to be used in an accumulative manner:

```python
vis_grid = np.zeros((corr,ny,nx), dtype=np.complex64)

vis_grid = grid(vis_0, ..., grid=vis_grid)
vis_grid = grid(vis_1, ..., grid=vis_grid)
```
in addition to the original formulation:

```python
vis_grid = grid(vis_0, ..., ny, nx)
vis_grid += grid(vis_1, ..., ny, nx)
```

- [x] Tests added / passed
- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API
