### PR TITLE
Swap gridding correlation dims

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,26 @@
 - [ ] Tests added / passed
+
+  ```bash
+  $ py.test -v -s africanus
+  ```
+
+  If the pycodestyle tests fail, the quickest way to correct
+  this is to run `autopep8` and then `pycodestyle` to fix the
+  remaining issues.
+
+  ```
+  $ pip install -U autopep8 pycodestyle
+  $ autopep8 -r -i africanus
+  $ pycodestyle africanus
+  ```
+
 - [ ] Fully documented, including `HISTORY.rst` for all changes
       and one of the `docs/*-api.rst` files for new API
+
+  To build the docs locally:
+
+  ```
+  pip install -r requirements.readthedocs.txt
+  cd docs
+  READTHEDOCS=True make html
+  ```

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ Ready to contribute? Here's how to set up `codex-africanus` for local developmen
 
     $ mkvirtualenv codex-africanus
     $ cd codex-africanus/
-    $ python setup.py develop
+    $ pip install -e .
 
 4. Create a branch for local development::
 
@@ -76,14 +76,15 @@ Ready to contribute? Here's how to set up `codex-africanus` for local developmen
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+5. When you're done making changes, check that your changes
+   pass the test cases, fixup your PEP8 compliance,
+   and check for any code style issues:
 
-    $ flake8 codex-africanus tests
-    $ python setup.py test or py.test
-    $ tox
+    $ py.test -v africanus
+    $ autopep8 -r -i africanus
+    $ pycodestyle africanus
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   To get autopep8 and pycodestyle, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -101,8 +102,8 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+   feature to the list in HISTORY.rst.
+3. The pull request should work for Python 2.7, 3.5 and 3.6. Check
    https://travis-ci.org/ska-sa/codex-africanus/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/africanus/gridding/simple/dask.py
+++ b/africanus/gridding/simple/dask.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ...util.docs import on_rtd
+from .gridding import (grid as np_grid_fn, degrid as np_degrid_fn)
+from ...util.docs import on_rtd, mod_docs
 from ...util.requirements import have_packages, MissingPackageException
 
 _package_requirements = ('dask.array', 'toolz')
@@ -20,7 +21,6 @@ if not have_requirements or on_rtd():
 else:
     import numpy as np
     import dask.array as da
-    from .gridding import (grid as np_grid_fn, degrid as np_degrid_fn)
 
     def grid(vis, uvw, flags, weights, ref_wave,
              convolution_filter, nx=1024, ny=1024):
@@ -66,65 +66,17 @@ else:
                             convolution_filter=convolution_filter,
                             dtype=np.complex64)
 
-grid.__doc__ = """
-dask wrapper for :func:`~africanus.gridding.simple.grid`.
+grid.__doc__ = mod_docs(np_grid_fn.__doc__,
+                          [(":class:`numpy.ndarray`",
+                            ":class:`dask.array.Array`"),
+                           ("np.ones_like", "da.ones_like"),
+                           ("np.zeros_like", "da.zeros_like")])
 
-Each ``row`` chunk of ``vis`` is gridded separately and the
-resulting images are summed in a parallel reduction.
+degrid.__doc__ = mod_docs(np_degrid_fn.__doc__,
+                          [(":class:`numpy.ndarray`",
+                            ":class:`dask.array.Array`"),
+                           ("np.ones_like", "da.ones_like"),
+                           ("np.zeros_like", "da.zeros_like")])
 
-Parameters
-----------
-vis : :class:`dask.array.Array`
-    complex64 visibility array of shape :code:`(row, chan, corr_1, corr_2)`
-uvw : np.ndarray
-    float64 array of UVW coordinates of shape :code:`(row, 3)`
-flags : :class:`dask.array.Array`
-    flagged data array of shape :code:`(row, chan, corr_1, corr_2)`.
-    Any positive quantity will indicate that the corresponding
-    visibility should be flagged.
-    Set this to ``dask.array.zeros_like(vis, dtype=np.bool)``
-    as default.
-weights : :class:`dask.array.Array`
-    float32 or float64 array of weights of shape :code:`(row, chan, corr_1, corr_2)`.
-    Set this to
-    ``dask.array.ones_like(vis, dtype=np.float32)`` as default.
-ref_wave : :class:`dask.array.Array`
-    float64 array of wavelengths of shape :code:`(chan,)`
-convolution_filter : :class:`~africanus.filters.ConvolutionFilter`
-    Convolution filter
-nx : integer, optional
-    Size of the grid's X dimension
-ny : integer, optional
-    Size of the grid's Y dimension
 
-Returns
--------
-:class:`dask.array.Array`
-    (ny, nx, corr_1, corr_2) complex64 array of gridded visibilities
-    constructed by summing convolutional weights.
-"""
 
-degrid.__doc__ = """
-dask wrapper for :func:`~africanus.gridding.simple.degrid`.
-
-Parameters
-----------
-grid : :class:`dask.array.Array`
-    float or complex grid of visibilities
-    of shape :code:`(ny, nx, corr_1, corr_2)`
-uvw : :class:`dask.array.Array`
-    float64 array of UVW coordinates of shape :code:`(row, 3)`
-weights : :class:`dask.array.Array`
-    float32 or float64 array of weights of shape
-    :code:`(row, chan, corr_1, corr_2)`. Set this to
-    ``dask.array.ones_like(vis, dtype=np.float32)`` as default.
-ref_wave : :class:`dask.array.Array`
-    float64 array of wavelengths of shape :code:`(chan,)`
-convolution_filter :  :class:`~africanus.filters.ConvolutionFilter`
-    Convolution Filter
-
-Returns
--------
-:class:`dask.array.Array`
-    :code:`(row, chan, corr_1, corr_2)` complex64 visibilities
-"""

--- a/africanus/gridding/simple/dask.py
+++ b/africanus/gridding/simple/dask.py
@@ -20,35 +20,47 @@ if not have_requirements or on_rtd():
 else:
     import numpy as np
     import dask.array as da
-    from .gridding import (grid as nb_grid_fn, degrid as nb_degrid_fn)
+    from .gridding import (grid as np_grid_fn, degrid as np_degrid_fn)
 
     def grid(vis, uvw, flags, weights, ref_wave,
              convolution_filter, nx=1024, ny=1024):
         """ Documentation below """
 
+        # Creation correlation dimension strings for each correlation
+        corrs = tuple('corr-%d' for i in range(len(vis.shape[2:])))
+
         # Unfortunately necessary to introduce an extra dim
         # for atop to work properly
-        def _grid_fn(*args, **kwargs):
-            return nb_grid_fn(*args, **kwargs)[None, :, :, :]
+        def _grid_fn(vis, uvw, flags, weights, ref_wave, convolution_filter):
+            return np_grid_fn(vis[0], uvw[0], flags[0], weights[0],
+                                ref_wave[0], convolution_filter,
+                                nx=nx, ny=ny)[None,:]
 
-        return da.core.atop(_grid_fn, ("row", "corr", "ny", "nx"),
-                            vis, ("row", "chan", "corr"),
+        # Get grids, stacked by row
+        grids = da.core.atop(_grid_fn, ("row", "ny", "nx") + corrs,
+                            vis, ("row", "chan") + corrs,
                             uvw, ("row", "(u,v,w)"),
-                            flags, ("row", "chan", "corr"),
-                            weights, ("row", "chan", "corr"),
+                            flags, ("row", "chan") + corrs,
+                            weights, ("row", "chan") + corrs,
                             ref_wave, ("chan",),
                             new_axes={"ny": ny, "nx": nx},
-                            adjust_chunks={"row": lambda n: 1},
-                            concatenate=True,
+                            adjust_chunks={"row": 1},
                             convolution_filter=convolution_filter,
-                            dtype=np.complex64).sum(axis=0)
+                            dtype=np.complex64)
+
+        # Sum grids over the row dimension to produce (ny, nx, corr_1, corr_2)
+        return grids.sum(axis=0)
 
     def degrid(grid, uvw, weights, ref_wave, convolution_filter):
         """ Documentation below """
-        return da.core.atop(nb_degrid_fn, ("row", "chan", "corr"),
-                            grid, ("corr", "ny", "nx"),
+
+        # Creation correlation dimension strings for each correlation
+        corrs = tuple('corr-%d' for i in range(len(grid.shape[2:])))
+
+        return da.core.atop(np_degrid_fn, ("row", "chan") + corrs,
+                            grid, ("ny", "nx") + corrs,
                             uvw, ("row", "(u,v,w)"),
-                            weights, ("row", "chan", "corr"),
+                            weights, ("row", "chan") + corrs,
                             ref_wave, ("chan",),
                             concatenate=True,
                             convolution_filter=convolution_filter,
@@ -63,20 +75,21 @@ resulting images are summed in a parallel reduction.
 Parameters
 ----------
 vis : :class:`dask.array.Array`
-    complex64 visibility array of shape (row, chan, corr)
+    complex64 visibility array of shape :code:`(row, chan, corr_1, corr_2)`
 uvw : np.ndarray
-    float64 array of UVW coordinates of shape (row, 3)
+    float64 array of UVW coordinates of shape :code:`(row, 3)`
 flags : :class:`dask.array.Array`
-    flagged data array of shape (row, chan, corr).
+    flagged data array of shape :code:`(row, chan, corr_1, corr_2)`.
     Any positive quantity will indicate that the corresponding
     visibility should be flagged.
     Set this to ``dask.array.zeros_like(vis, dtype=np.bool)``
     as default.
 weights : :class:`dask.array.Array`
-    float32 or float64 array of weights. Set this to
+    float32 or float64 array of weights of shape :code:`(row, chan, corr_1, corr_2)`.
+    Set this to
     ``dask.array.ones_like(vis, dtype=np.float32)`` as default.
 ref_wave : :class:`dask.array.Array`
-    float64 array of wavelengths of shape (chan,)
+    float64 array of wavelengths of shape :code:`(chan,)`
 convolution_filter : :class:`~africanus.filters.ConvolutionFilter`
     Convolution filter
 nx : integer, optional
@@ -87,7 +100,7 @@ ny : integer, optional
 Returns
 -------
 :class:`dask.array.Array`
-    (corr, ny, nx) complex64 array of gridded visibilities
+    (ny, nx, corr_1, corr_2) complex64 array of gridded visibilities
     constructed by summing convolutional weights.
 """
 
@@ -98,19 +111,20 @@ Parameters
 ----------
 grid : :class:`dask.array.Array`
     float or complex grid of visibilities
-    of shape (corr, ny, nx)
+    of shape :code:`(ny, nx, corr_1, corr_2)`
 uvw : :class:`dask.array.Array`
-    float64 array of UVW coordinates of shape (row, 3)
+    float64 array of UVW coordinates of shape :code:`(row, 3)`
 weights : :class:`dask.array.Array`
-    float32 or float64 array of weights. Set this to
+    float32 or float64 array of weights of shape
+    :code:`(row, chan, corr_1, corr_2)`. Set this to
     ``dask.array.ones_like(vis, dtype=np.float32)`` as default.
 ref_wave : :class:`dask.array.Array`
-    float64 array of wavelengths of shape (chan,)
+    float64 array of wavelengths of shape :code:`(chan,)`
 convolution_filter :  :class:`~africanus.filters.ConvolutionFilter`
     Convolution Filter
 
 Returns
 -------
 :class:`dask.array.Array`
-    (chan, corr) complex64 visibilities
+    :code:`(row, chan, corr_1, corr_2)` complex64 visibilities
 """

--- a/africanus/gridding/simple/dask.py
+++ b/africanus/gridding/simple/dask.py
@@ -33,20 +33,20 @@ else:
         # for atop to work properly
         def _grid_fn(vis, uvw, flags, weights, ref_wave, convolution_filter):
             return np_grid_fn(vis[0], uvw[0], flags[0], weights[0],
-                                ref_wave[0], convolution_filter,
-                                nx=nx, ny=ny)[None,:]
+                              ref_wave[0], convolution_filter,
+                              nx=nx, ny=ny)[None, :]
 
         # Get grids, stacked by row
         grids = da.core.atop(_grid_fn, ("row", "ny", "nx") + corrs,
-                            vis, ("row", "chan") + corrs,
-                            uvw, ("row", "(u,v,w)"),
-                            flags, ("row", "chan") + corrs,
-                            weights, ("row", "chan") + corrs,
-                            ref_wave, ("chan",),
-                            new_axes={"ny": ny, "nx": nx},
-                            adjust_chunks={"row": 1},
-                            convolution_filter=convolution_filter,
-                            dtype=np.complex64)
+                             vis, ("row", "chan") + corrs,
+                             uvw, ("row", "(u,v,w)"),
+                             flags, ("row", "chan") + corrs,
+                             weights, ("row", "chan") + corrs,
+                             ref_wave, ("chan",),
+                             new_axes={"ny": ny, "nx": nx},
+                             adjust_chunks={"row": 1},
+                             convolution_filter=convolution_filter,
+                             dtype=np.complex64)
 
         # Sum grids over the row dimension to produce (ny, nx, corr_1, corr_2)
         return grids.sum(axis=0)
@@ -67,16 +67,13 @@ else:
                             dtype=np.complex64)
 
 grid.__doc__ = mod_docs(np_grid_fn.__doc__,
-                          [(":class:`numpy.ndarray`",
+                        [(":class:`numpy.ndarray`",
                             ":class:`dask.array.Array`"),
-                           ("np.ones_like", "da.ones_like"),
-                           ("np.zeros_like", "da.zeros_like")])
+                         ("np.ones_like", "da.ones_like"),
+                         ("np.zeros_like", "da.zeros_like")])
 
 degrid.__doc__ = mod_docs(np_degrid_fn.__doc__,
                           [(":class:`numpy.ndarray`",
                             ":class:`dask.array.Array`"),
                            ("np.ones_like", "da.ones_like"),
                            ("np.zeros_like", "da.zeros_like")])
-
-
-

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -6,6 +6,13 @@ from __future__ import print_function
 
 from operator import mul
 
+try:
+    # in python3, reduce is in functools
+    from functools import reduce
+except ImportError:
+    # I guess this is python2
+    pass
+
 import numba
 import numpy as np
 

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -97,6 +97,13 @@ def grid(vis, uvw, flags, weights, ref_wave,
     ``ref_wave`` reference wavelengths using
     the specified ``convolution_filter``.
 
+    Variable numbers of correlations are supported.
+
+    * :code:`(row, chan, corr_1, corr_2)` ``vis`` will result in a
+      :code:`(ny, nx, corr_1, corr_2)` ``grid``.
+    * :code:`(row, chan, corr_1)` ``vis`` will result in a
+      :code:`(ny, nx, corr_1)` ``grid``.
+
     Parameters
     ----------
     vis : np.ndarray
@@ -110,7 +117,7 @@ def grid(vis, uvw, flags, weights, ref_wave,
         flagged array of shape :code:`(row, chan, corr_1, corr_2)`.
         Any positive quantity will indicate that the corresponding
         visibility should be flagged.
-        Set to ``np.zero_like(vis, dtype=np.bool)`` as default.
+        Set to ``np.zeros_like(vis, dtype=np.bool)`` as default.
     ref_wave : np.ndarray
         float64 array of wavelengths of shape :code:`(chan,)`
     convolution_filter :  :class:`~africanus.filters.ConvolutionFilter`
@@ -128,7 +135,9 @@ def grid(vis, uvw, flags, weights, ref_wave,
     Returns
     -------
     np.ndarray
-        :code:`(ny, nx, corr_1, corr_2)` complex ndarray of gridded visibilities
+        :code:`(ny, nx, corr_1, corr_2)` complex ndarray of
+        gridded visibilities. The number of correlations may vary,
+        depending on the shape of vis.
     """
 
     # Flatten the correlation dimensions
@@ -148,6 +157,14 @@ def grid(vis, uvw, flags, weights, ref_wave,
 def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
     """
     Convolutional degridder (continuum)
+
+    Variable numbers of correlations are supported.
+
+    * :code:`(ny, nx, corr_1, corr_2)` ``grid`` will result in a
+      :code:`(row, chan, corr_1, corr_2)` ``vis``
+
+    * :code:`(ny, nx, corr_1)` ``grid`` will result in a
+      :code:`(row, chan, corr_1)` ``vis``
 
     Parameters
     ----------

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -29,9 +29,9 @@ def _nb_grid(vis, uvw, flags, weights, ref_wave,
     flat_corrs = grid.shape[2]
 
     # Flatten correlation dimension for easier loop handling
-    fvis = vis.reshape((nrow,nchan,flat_corrs))
-    fflags = flags.reshape((nrow,nchan,flat_corrs))
-    fweights = weights.reshape((nrow,nchan,flat_corrs))
+    fvis = vis.reshape((nrow, nchan, flat_corrs))
+    fflags = flags.reshape((nrow, nchan, flat_corrs))
+    fweights = weights.reshape((nrow, nchan, flat_corrs))
 
     filter_index = np.arange(-cf.half_sup, cf.half_sup+1)
 
@@ -154,6 +154,7 @@ def grid(vis, uvw, flags, weights, ref_wave,
     return _nb_grid(vis, uvw, flags, weights, ref_wave,
                     convolution_filter, grid)
 
+
 def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
     """
     Convolutional degridder (continuum)
@@ -197,7 +198,6 @@ def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
 
     for corr in corrs:
         flat_corrs *= corr
-
 
     vis = np.zeros((nrow, nchan, flat_corrs), dtype=np.complex64)
     grid = grid.reshape((ny, nx, flat_corrs))

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from operator import mul
+
 import numba
 import numpy as np
 
@@ -19,9 +21,18 @@ def _nb_grid(vis, uvw, flags, weights, ref_wave,
     """
     cf = convolution_filter
 
-    ny, nx = grid.shape[1:]
+    nrow, nchan = vis.shape[0:2]
+    assert nchan == ref_wave.shape[0]
+    corrs = vis.shape[2:]
 
-    assert vis.shape[1] == ref_wave.shape[0]
+    ny, nx = grid.shape[0:2]
+    flat_corrs = grid.shape[2]
+
+    # Flatten correlation dimension for easier loop handling
+    fvis = vis.reshape((nrow,nchan,flat_corrs))
+    fflags = flags.reshape((nrow,nchan,flat_corrs))
+    fweights = weights.reshape((nrow,nchan,flat_corrs))
+
     filter_index = np.arange(-cf.half_sup, cf.half_sup+1)
 
     for r in range(uvw.shape[0]):                 # row (vis)
@@ -63,17 +74,17 @@ def _nb_grid(vis, uvw, flags, weights, ref_wave,
                     conv_weight = v_tap*u_tap
                     grid_u = disc_u + conv_u + nx // 2
 
-                    for c in range(vis.shape[2]):      # correlation
+                    for c in range(flat_corrs):      # correlation
                         # Ignore flagged correlations
-                        if flags[r, f, c] > 0:
+                        if fflags[r, f, c] > 0:
                             continue
 
                         # Grid the visibility
-                        grid[c, grid_v, grid_u] += (vis[r, f, c] *
+                        grid[grid_v, grid_u, c] += (fvis[r, f, c] *
                                                     conv_weight *
-                                                    weights[r, f, c])
+                                                    fweights[r, f, c])
 
-    return grid
+    return grid.reshape((ny, nx) + corrs)
 
 
 def grid(vis, uvw, flags, weights, ref_wave,
@@ -89,19 +100,19 @@ def grid(vis, uvw, flags, weights, ref_wave,
     Parameters
     ----------
     vis : np.ndarray
-        complex64 visibility array of shape (row, chan, corr)
+        complex visibility array of shape :code:`(row, chan, corr_1, corr_2)`
     uvw : np.ndarray
-        float64 array of UVW coordinates of shape (row, 3)
+        float64 array of UVW coordinates of shape :code:`(row, 3)`
     weights : np.ndarray
         float32 or float64 array of weights. Set this to
         ``np.ones_like(vis, dtype=np.float32)`` as default.
     flags : np.ndarray
-        flagged array of shape (row, chan, corr).
+        flagged array of shape :code:`(row, chan, corr_1, corr_2)`.
         Any positive quantity will indicate that the corresponding
         visibility should be flagged.
         Set to ``np.zero_like(vis, dtype=np.bool)`` as default.
     ref_wave : np.ndarray
-        float64 array of wavelengths of shape (chan,)
+        float64 array of wavelengths of shape :code:`(chan,)`
     convolution_filter :  :class:`~africanus.filters.ConvolutionFilter`
         Convolution filter
     nx : integer, optional
@@ -109,7 +120,7 @@ def grid(vis, uvw, flags, weights, ref_wave,
     ny : integer, optional
         Size of the grid's Y dimension
     grid : np.ndarray, optional
-        complex64/complex128 array of shape (corr, ny, nx)
+        complex64/complex128 array of shape :code:`(ny, nx, corr_1, corr_2)`
         If supplied, this array will be used as the gridding target,
         and ``nx`` and ``ny`` will be derived from this grid's
         dimensions.
@@ -117,15 +128,22 @@ def grid(vis, uvw, flags, weights, ref_wave,
     Returns
     -------
     np.ndarray
-        (corr, ny, nx) complex64 ndarray of gridded visibilities
+        :code:`(ny, nx, corr_1, corr_2)` complex ndarray of gridded visibilities
     """
 
+    # Flatten the correlation dimensions
+    corrs = vis.shape[2:]
+    flat_corrs = (reduce(mul, corrs),)
+
+    # Create grid of flatten correlations or reshape
     if grid is None:
-        grid = np.zeros((vis.shape[2], ny, nx), dtype=np.complex64)
+        grid = np.zeros((ny, nx) + flat_corrs, dtype=vis.dtype)
+    else:
+        ny, nx = grid.shape[0:2]
+        grid = grid.reshape((ny, nx) + flat_corrs)
 
     return _nb_grid(vis, uvw, flags, weights, ref_wave,
                     convolution_filter, grid)
-
 
 def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
     """
@@ -135,28 +153,38 @@ def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
     ----------
     grid : np.ndarray
         float or complex grid of visibilities
-        of shape (corr, ny, nx)
+        of shape :code:`(ny, nx, corr_1, corr_2)`
     uvw : np.ndarray
-        float64 array of UVW coordinates of shape (row, 3)
+        float64 array of UVW coordinates of shape :code:`(row, 3)`
     weights : np.ndarray
         float32 or float64 array of weights. Set this to
         ``np.ones_like(vis, dtype=np.float32)`` as default.
     ref_wave : np.ndarray
-        float64 array of wavelengths of shape (chan,)
+        float64 array of wavelengths of shape :code:`(chan,)`
     convolution_filter :  :class:`~africanus.filters.ConvolutionFilter`
         Convolution Filter
 
     Returns
     -------
     np.ndarray
-        (row, chan, corr) complex64 ndarray of visibilities
+        :code:`(row, chan, corr_1, corr_2)` complex ndarray of visibilities
     """
     cf = convolution_filter
-    ncorr, nx, ny = grid.shape
+
+    ny, nx = grid.shape[0:2]
+    corrs = grid.shape[2:]
     nchan = ref_wave.shape[0]
     nrow = uvw.shape[0]
 
-    vis = np.zeros((nrow, nchan, ncorr), dtype=np.complex64)
+    flat_corrs = 1
+
+    for corr in corrs:
+        flat_corrs *= corr
+
+
+    vis = np.zeros((nrow, nchan, flat_corrs), dtype=np.complex64)
+    grid = grid.reshape((ny, nx, flat_corrs))
+    weights = weights.reshape((nrow, nchan, flat_corrs))
 
     assert vis.shape[1] == ref_wave.shape[0]
     filter_index = np.arange(-cf.half_sup, cf.half_sup+1)
@@ -200,12 +228,12 @@ def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
                     grid_u = disc_u + conv_u + nx // 2
 
                     # Correlation
-                    for c in range(vis.shape[2]):
-                        vis[r, f, c] += (grid[c, grid_v, grid_u] *
+                    for c in range(flat_corrs):
+                        vis[r, f, c] += (grid[grid_v, grid_u, c] *
                                          conv_weight *
                                          weights[r, f, c])
 
-    return vis
+    return vis.reshape((nrow, nchan) + corrs)
 
 # jit the functions if this is not RTD otherwise
 # use the private funcs for generating docstrings
@@ -213,5 +241,6 @@ def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
 
 if not on_rtd():
     degrid = numba.jit(nopython=True, nogil=True, cache=True)(_degrid)
+    # degrid = _degrid
 else:
     degrid = _degrid


### PR DESCRIPTION
Previously, the result of gridding were arrays of shape `(fcorr, ny, nx)` where `fcorr` was the total number of correlations. This has been changed so that

- `(ny, nx, corr_1, corr_2)` and
- `(ny, nx, corr_1)`

shapes are supported. The correlation dimensions are derived from the input visibility arrays.

- [x] Tests added / passed
- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API