### PR TITLE
Test parallactic angle backends if available

### DIFF
--- a/africanus/rime/parangles.py
+++ b/africanus/rime/parangles.py
@@ -105,11 +105,13 @@ def parallactic_angles(times, antenna_positions, field_centre, **kwargs):
     Notes
     -----
 
-    * The casa backend uses an ``AZELGEO`` frame in order
+    * The python-casacore backend uses an ``AZELGEO`` frame in order
       to more closely agree with the astropy backend,
       but slightly differs from ``AZEL`` frame using in MeqTrees.
     * The astropy backend is slightly more than 2x faster than
       the casa backend
+    * The astropy and python-casacore differ by at most
+      10 arcseconds
 
     Parameters
     ----------

--- a/africanus/rime/parangles.py
+++ b/africanus/rime/parangles.py
@@ -88,8 +88,8 @@ else:
 
         ap = EarthLocation.from_geocentric(
             ap[:, 0], ap[:, 1], ap[:, 2], unit='m')
-        fc = SkyCoord(ra=fc[0], dec=fc[1], unit=units.rad, frame='itrs')
-        pole = SkyCoord(ra=0, dec=90, unit=units.deg, frame='itrs')
+        fc = SkyCoord(ra=fc[0], dec=fc[1], unit=units.rad, frame='fk5')
+        pole = SkyCoord(ra=0, dec=90, unit=units.deg, frame='fk5')
 
         cirs_frame = CIRS(obstime=times)
         pole_cirs = pole.transform_to(cirs_frame)

--- a/africanus/rime/parangles.py
+++ b/africanus/rime/parangles.py
@@ -15,8 +15,7 @@ _casa_requirements = ('pyrap.measures', 'pyrap.quanta')
 have_casa_requirements = have_packages(*_casa_requirements)
 
 if not have_casa_requirements:
-    def casa_parallactic_angles(times, antenna_positions, field_centre,
-                                antenna_frame):
+    def casa_parallactic_angles(times, antenna_positions, field_centre):
         raise MissingPackageException(*_casa_requirements)
 else:
     _discovered_backends.append('casa')
@@ -27,8 +26,7 @@ else:
     # Create a measures server
     meas_serv = pyrap.measures.measures()
 
-    def casa_parallactic_angles(times, antenna_positions, field_centre,
-                                antenna_frame='itrf'):
+    def casa_parallactic_angles(times, antenna_positions, field_centre):
         """
         Computes parallactic angles per timestep for the given
         reference antenna position and field centre.
@@ -39,7 +37,7 @@ else:
 
         # Create position measures for each antenna
         reference_positions = [meas_serv.position(
-                                    antenna_frame,
+                                    'itrf',
                                     *(pq.quantity(x, 'm') for x in pos))
                                for pos in antenna_positions]
 
@@ -63,8 +61,7 @@ _astropy_requirements = ('astropy',)
 have_astropy_requirements = have_packages(*_astropy_requirements)
 
 if not have_astropy_requirements:
-    def astropy_parallactic_angles(times, antenna_positions, field_centre,
-                                   antenna_frame):
+    def astropy_parallactic_angles(times, antenna_positions, field_centre):
         raise MissingPackageException(*_astropy_requirements)
 else:
     _discovered_backends.append('astropy')
@@ -74,8 +71,7 @@ else:
     from astropy.time import Time
     from astropy import units
 
-    def astropy_parallactic_angles(times, antenna_positions, field_centre,
-                                   antenna_frame='itrs'):
+    def astropy_parallactic_angles(times, antenna_positions, field_centre):
         """
         Computes parallactic angles per timestep for the given
         reference antenna position and field centre.
@@ -135,10 +131,6 @@ def parallactic_angles(times, antenna_positions, field_centre, **kwargs):
           by multiplying the ``times`` and ``antenna_position``
           arrays. It exist solely for testing.
 
-    antenna_frame : {'itrs'}, optional
-        The coordinate system of the antenna frame.
-        Defaults to 'itrs' for the moment.
-
     Returns
     -------
     :class:`numpy.ndarray`
@@ -154,24 +146,18 @@ def parallactic_angles(times, antenna_positions, field_centre, **kwargs):
             raise ValueError("None of the standard backends "
                              "%s are installed" % _standard_backends)
 
-    aframe = kwargs.pop('antenna_frame', 'itrs')
-
     if not field_centre.shape == (2,):
         raise ValueError("Invalid field_centre shape %s" %
                          (field_centre.shape,))
 
-    if aframe not in ('itrs'):
-        raise ValueError("Invalid antenna_frame %s" % aframe)
-
     if backend == 'astropy':
-        return astropy_parallactic_angles(times, antenna_positions,
-                                          field_centre, antenna_frame=aframe)
+        return astropy_parallactic_angles(times,
+                                          antenna_positions,
+                                          field_centre)
     elif backend == 'casa':
-        if aframe == 'itrs':
-            aframe = 'itrf'
-
-        return casa_parallactic_angles(times, antenna_positions,
-                                       field_centre, antenna_frame=aframe)
+        return casa_parallactic_angles(times,
+                                       antenna_positions,
+                                       field_centre)
     elif backend == 'test':
         return times[:, None]*(antenna_positions.sum(axis=1)[None, :])
     else:

--- a/tests/test_rime.py
+++ b/tests/test_rime.py
@@ -219,7 +219,7 @@ def test_compare_astropy_and_casa(obs_and_tol, wsrt_ants):
     """
     Compare astropy and python-casacore parallactic angle implementations.
     More work needs to be done here to get things lined up closer,
-    but the tolerances above suggest nothing > 10s.
+    but the tolerances above suggest nothing > 10 arcseconds.
     """
     import numpy as np
     from africanus.rime import parallactic_angles

--- a/tests/test_rime.py
+++ b/tests/test_rime.py
@@ -105,8 +105,17 @@ def test_feed_rotation():
     assert np.allclose(fr, np_expr.reshape(10,5,2,2))
 
 
+from africanus.rime.parangles import _discovered_backends
+no_casa = 'casa' not in _discovered_backends
+no_astropy = 'astropy' not in _discovered_backends
 
-def test_parallactic_angles():
+@pytest.mark.parametrize('backend', [
+    'test',
+    pytest.param('casa', marks=pytest.mark.skipif(no_casa,
+                        reason='python-casascore not installed')),
+    pytest.param('astropy', marks=pytest.mark.skipif(no_astropy,
+                        reason="astropy not installed"))])
+def test_parallactic_angles(backend):
     import numpy as np
     from africanus.rime import parallactic_angles
 
@@ -114,7 +123,7 @@ def test_parallactic_angles():
     ant = np.random.random((4,3)).astype(np.float64)
     fc = np.random.random((2,)).astype(np.float64)
 
-    pa = parallactic_angles(time, ant, fc, backend='test')
+    pa = parallactic_angles(time, ant, fc, backend=backend)
     assert pa.shape == (5,4)
 
 
@@ -174,7 +183,13 @@ def test_dask_phase_delay():
 
 
 @pytest.mark.skipif(not have_requirements, reason="requirements not installed")
-def test_dask_parallactic_angles():
+@pytest.mark.parametrize('backend', [
+    'test',
+    pytest.param('casa', marks=pytest.mark.skipif(no_casa,
+                        reason='python-casascore not installed')),
+    pytest.param('astropy', marks=pytest.mark.skipif(no_astropy,
+                        reason="astropy not installed"))])
+def test_dask_parallactic_angles(backend):
     import dask.array as da
     from africanus.rime import parallactic_angles as np_parangle
     from africanus.rime.dask import parallactic_angles as da_parangle
@@ -183,13 +198,14 @@ def test_dask_parallactic_angles():
     np_ants = np.random.random(size=(4,3))
     np_fc = np.random.random(size=2)
 
-    np_pa = np_parangle(np_times, np_ants, np_fc, backend='test')
+    np_pa = np_parangle(np_times, np_ants, np_fc, backend=backend)
+    np_pa = np.asarray(np_pa)
 
     da_times = da.from_array(np_times, chunks=(2,3))
     da_ants = da.from_array(np_ants, chunks=((2,2),3))
     da_fc = da.from_array(np_fc, chunks=2)
 
-    da_pa = da_parangle(da_times, da_ants, da_fc, backend='test')
+    da_pa = da_parangle(da_times, da_ants, da_fc, backend=backend)
 
     from pprint import pprint
 

--- a/tests/test_rime.py
+++ b/tests/test_rime.py
@@ -306,7 +306,7 @@ def test_dask_phase_delay():
                         reason='python-casascore not installed')),
     pytest.param('astropy', marks=pytest.mark.skipif(no_astropy,
                         reason="astropy not installed"))])
-@pytest.mark.parametrize('observation', [(2018,01,01,4)])
+@pytest.mark.parametrize('observation', [(2018, 1, 1,4)])
 def test_dask_parallactic_angles(observation, wsrt_ants, backend):
     import dask.array as da
     from africanus.rime import parallactic_angles as np_parangle

--- a/tests/test_rime.py
+++ b/tests/test_rime.py
@@ -105,6 +105,49 @@ def test_feed_rotation():
     assert np.allclose(fr, np_expr.reshape(10,5,2,2))
 
 
+import math
+
+def _julian_day(year, month, day):
+    """
+    Given a Anno Dominei date, computes the Julian Date in days.
+
+    Parameters
+    ----------
+    year : int
+    month : int
+    day : int
+
+    Returns
+    -------
+    float
+        Julian Date
+    """
+
+    # Formula below from
+    # http://scienceworld.wolfram.com/astronomy/JulianDate.html
+    # Also agrees with https://gist.github.com/jiffyclub/1294443
+    return (367*year - int(7*(year + int((month+9)/12))/4)
+            - int((3*(int(year + (month - 9)/7)/100)+1)/4)
+            + int(275*month/9) + day + 1721028.5)
+
+def _modified_julian_date(year, month, day):
+    """
+    Given a Anno Dominei date, computes the Modified Julian Date in days.
+
+    Parameters
+    ----------
+    year : int
+    month : int
+    day : int
+
+    Returns
+    -------
+    float
+        Modified Julian Date
+    """
+
+    return _julian_day(year, month, day) - 2400000.5
+
 from africanus.rime.parangles import _discovered_backends
 no_casa = 'casa' not in _discovered_backends
 no_astropy = 'astropy' not in _discovered_backends
@@ -119,7 +162,14 @@ def test_parallactic_angles(backend):
     import numpy as np
     from africanus.rime import parallactic_angles
 
-    time = np.random.random((5,)).astype(np.float64)
+    # Four hour Observation on 01/01/2017
+    start = _modified_julian_date(2017, 1, 1)
+    end = start + 4.0 / 24
+
+    start*= 86400.
+    end *= 86400.
+
+    time = np.linspace(start, end, 5)
     ant = np.random.random((4,3)).astype(np.float64)
     fc = np.random.random((2,)).astype(np.float64)
 
@@ -194,7 +244,15 @@ def test_dask_parallactic_angles(backend):
     from africanus.rime import parallactic_angles as np_parangle
     from africanus.rime.dask import parallactic_angles as da_parangle
 
-    np_times = np.random.random(size=(5,))
+    # Four hour Observation on 01/01/2017
+    start = _modified_julian_date(2017, 1, 1)
+    end = start + 4.0 / 24
+
+    # Convert to seconds
+    start *= 86400.
+    end *= 86400.
+
+    np_times = np.linspace(start, end, 5)
     np_ants = np.random.random(size=(4,3))
     np_fc = np.random.random(size=2)
 

--- a/tests/test_rime.py
+++ b/tests/test_rime.py
@@ -194,7 +194,7 @@ no_astropy = 'astropy' not in _discovered_backends
                         reason='python-casascore not installed')),
     pytest.param('astropy', marks=pytest.mark.skipif(no_astropy,
                         reason="astropy not installed"))])
-@pytest.mark.parametrize('observation', [(2018,01,01,4)])
+@pytest.mark.parametrize('observation', [(2018, 1, 1, 4)])
 def test_parallactic_angles(observation, wsrt_ants, backend):
     import numpy as np
     from africanus.rime import parallactic_angles
@@ -212,9 +212,9 @@ def test_parallactic_angles(observation, wsrt_ants, backend):
                     reason="Neither python-casacore or astropy installed")
 # Parametrize on observation length and error tolerance
 @pytest.mark.parametrize('obs_and_tol', [
-    ((2018,01,01,4), "10s"),
-    ((2018,02,20, 8), "10s"),
-    ((2018,11,02,4), "10s")])
+    ((2018, 1, 1, 4), "10s"),
+    ((2018, 2, 20, 8), "10s"),
+    ((2018, 11, 2, 4), "10s")])
 def test_compare_astropy_and_casa(obs_and_tol, wsrt_ants):
     """
     Compare astropy and python-casacore parallactic angle implementations.


### PR DESCRIPTION
PR contents:

- If python-casacore and astropy backends are available, test them too.
- python-casacore and astropy parallactic angles agree within 10 arcseconds
- Hard-code python-casacore and astropy frames for now. Leave this for a proper review.

House-keeping

- [x] Tests added / passed
- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API.