### PR TITLE
Move numba functions outside functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.3 (2018-03-28)
 ------------------
 
+* Move numba implementations out of API functions. (:pr:`33`)
 * Zernike Polynomial Direction Dependent Effects (:pr:`18`, :pr:`30`)
 * Added division by :math:`n` to DFT.
   Fixed dask chunking issue.

--- a/africanus/dft/kernels.py
+++ b/africanus/dft/kernels.py
@@ -13,36 +13,62 @@ from ..constants import minus_two_pi_over_c
 from ..util.docs import doc_tuple_to_str
 
 
-def im_to_vis(image, uvw, lm, frequency, dtype=None):
+@numba.jit(nopython=True, nogil=True, cache=True)
+def _im_to_vis_impl(image, uvw, lm, frequency, vis_of_im):
+    # For each uvw coordinate
+    for row in range(uvw.shape[0]):
+        u, v, w = uvw[row]
 
-    @numba.jit(nopython=True, nogil=True, cache=True)
-    def _im_to_vis_impl(image, uvw, lm, frequency, vis_of_im):
+        # For each source
+        for source in range(lm.shape[0]):
+            l, m = lm[source]
+            n = np.sqrt(1.0 - l**2 - m**2) - 1.0
+
+            # e^(-2*pi*(l*u + m*v + n*w)/c)
+            real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
+
+            # Multiple in frequency for each channel
+            for chan in range(frequency.shape[0]):
+                p = real_phase * frequency[chan]
+
+                # Our phase input is purely imaginary
+                # so we can can elide a call to exp
+                # and just compute the cos and sin
+                # @simon does this really make a difference?
+                # I thought a complex exponential is evaluated
+                # as a sum of sin and cos anyway
+                vis_of_im[row, chan] += np.exp(p)*image[source, chan]/(n+1)
+
+    return vis_of_im
+
+
+@numba.jit(nopython=True, nogil=True, cache=True)
+def _vis_to_im_impl(vis, uvw, lm, frequency, im_of_vis):
+    # For each source
+    for source in range(lm.shape[0]):
+        l, m = lm[source]
+        n = np.sqrt(1.0 - l ** 2 - m ** 2) - 1.0
         # For each uvw coordinate
         for row in range(uvw.shape[0]):
             u, v, w = uvw[row]
 
-            # For each source
-            for source in range(lm.shape[0]):
-                l, m = lm[source]
-                n = np.sqrt(1.0 - l**2 - m**2) - 1.0
+            # e^(-2*pi*(l*u + m*v + n*w)/c)
+            real_phase = -minus_two_pi_over_c * (l * u + m * v + n * w)
 
-                # e^(-2*pi*(l*u + m*v + n*w)/c)
-                real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
+            # Multiple in frequency for each channel
+            for chan in range(frequency.shape[0]):
+                p = real_phase * frequency[chan]
 
-                # Multiple in frequency for each channel
-                for chan in range(frequency.shape[0]):
-                    p = real_phase * frequency[chan]
+                im_of_vis[source,
+                          chan] += (np.cos(p) * vis[row, chan].real -
+                                    np.sin(p) * vis[row, chan].imag)/(n+1)
+                # Note for the adjoint we don't need the imaginary part
+                # and we can elide the call to exp
 
-                    # Our phase input is purely imaginary
-                    # so we can can elide a call to exp
-                    # and just compute the cos and sin
-                    # @simon does this really make a difference?
-                    # I thought a complex exponential is evaluated
-                    # as a sum of sin and cos anyway
-                    vis_of_im[row, chan] += np.exp(p)*image[source, chan]/(n+1)
+    return im_of_vis
 
-        return vis_of_im
 
+def im_to_vis(image, uvw, lm, frequency, dtype=None):
     vis_of_im = np.zeros((uvw.shape[0], frequency.shape[0]),
                          dtype=np.complex128 if dtype is None else dtype)
 
@@ -50,32 +76,6 @@ def im_to_vis(image, uvw, lm, frequency, dtype=None):
 
 
 def vis_to_im(vis, uvw, lm, frequency, dtype=None):
-
-    @numba.jit(nopython=True, nogil=True, cache=True)
-    def _vis_to_im_impl(vis, uvw, lm, frequency, im_of_vis):
-        # For each source
-        for source in range(lm.shape[0]):
-            l, m = lm[source]
-            n = np.sqrt(1.0 - l ** 2 - m ** 2) - 1.0
-            # For each uvw coordinate
-            for row in range(uvw.shape[0]):
-                u, v, w = uvw[row]
-
-                # e^(-2*pi*(l*u + m*v + n*w)/c)
-                real_phase = -minus_two_pi_over_c * (l * u + m * v + n * w)
-
-                # Multiple in frequency for each channel
-                for chan in range(frequency.shape[0]):
-                    p = real_phase * frequency[chan]
-
-                    im_of_vis[source,
-                              chan] += (np.cos(p) * vis[row, chan].real -
-                                        np.sin(p) * vis[row, chan].imag)/(n+1)
-                    # Note for the adjoint we don't need the imaginary part
-                    # and we can elide the call to exp
-
-        return im_of_vis
-
     im_of_vis = np.zeros((lm.shape[0], frequency.shape[0]),
                          dtype=np.float64 if dtype is None else dtype)
 

--- a/africanus/rime/feeds.py
+++ b/africanus/rime/feeds.py
@@ -13,8 +13,6 @@ except ImportError:
 import numba
 import numpy as np
 
-from africanus.util.shapes import corr_shape
-
 
 @numba.njit(nogil=True, cache=True)
 def _nb_feed_rotation(parallactic_angles, feed_type, feed_rotation):

--- a/africanus/rime/parangles.py
+++ b/africanus/rime/parangles.py
@@ -68,7 +68,7 @@ else:
     _discovered_backends.append('astropy')
 
     from astropy.coordinates import (EarthLocation, SkyCoord,
-                                     AltAz, CIRS, Angle)
+                                     AltAz, CIRS)
     from astropy.time import Time
     from astropy import units
 

--- a/africanus/rime/phase.py
+++ b/africanus/rime/phase.py
@@ -10,37 +10,37 @@ import math
 import numba
 import numpy as np
 
-from ..constants import c as lightspeed, minus_two_pi_over_c
+from ..constants import minus_two_pi_over_c
 from ..util.docs import doc_tuple_to_str
 
 
+@numba.jit(nopython=True, nogil=True, cache=True)
+def _phase_delay_impl(uvw, lm, frequency, complex_phase):
+    # For each source
+    for source in range(lm.shape[0]):
+        l, m = lm[source]
+        n = math.sqrt(1.0 - l**2 - m**2) - 1.0
+
+        # For each uvw coordinate
+        for row in range(uvw.shape[0]):
+            u, v, w = uvw[row]
+            # e^(-2*pi*(l*u + m*v + n*w)/c)
+            real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
+
+            # Multiple in frequency for each channel
+            for chan in range(frequency.shape[0]):
+                p = real_phase * frequency[chan]
+
+                # Our phase input is purely imaginary
+                # so we can can elide a call to exp
+                # and just compute the cos and sin
+                complex_phase.real[source, row, chan] = math.cos(p)
+                complex_phase.imag[source, row, chan] = math.sin(p)
+
+    return complex_phase
+
+
 def phase_delay(uvw, lm, frequency, dtype=None):
-
-    @numba.jit(nopython=True, nogil=True, cache=True)
-    def _phase_delay_impl(uvw, lm, frequency, complex_phase):
-        # For each source
-        for source in range(lm.shape[0]):
-            l, m = lm[source]
-            n = math.sqrt(1.0 - l**2 - m**2) - 1.0
-
-            # For each uvw coordinate
-            for row in range(uvw.shape[0]):
-                u, v, w = uvw[row]
-                # e^(-2*pi*(l*u + m*v + n*w)/c)
-                real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
-
-                # Multiple in frequency for each channel
-                for chan in range(frequency.shape[0]):
-                    p = real_phase * frequency[chan]
-
-                    # Our phase input is purely imaginary
-                    # so we can can elide a call to exp
-                    # and just compute the cos and sin
-                    complex_phase.real[source, row, chan] = math.cos(p)
-                    complex_phase.imag[source, row, chan] = math.sin(p)
-
-        return complex_phase
-
     complex_phase = np.empty((lm.shape[0], uvw.shape[0], frequency.shape[0]),
                              dtype=np.complex128 if dtype is None else dtype)
 

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -9,8 +9,7 @@ from collections import namedtuple
 import numba
 import numpy as np
 
-from ..util.requirements import have_packages, MissingPackageException
-from ..util.docs import on_rtd, doc_tuple_to_str
+from ..util.docs import doc_tuple_to_str
 
 
 @numba.njit(nogil=True, cache=True)


### PR DESCRIPTION
This introduced a small overhead for every function call.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
