### PR TITLE
Fixed bug in im_to_vis

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,9 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
-
+* Fixed bug in im_to_vis. Added more tests for im_to_vis.
+  Removed division by :math:`n` since it is trivial to reinstate
+  after the fact. (:pr:`34`)
 * Move numba implementations out of API functions. (:pr:`33`)
 * Zernike Polynomial Direction Dependent Effects (:pr:`18`, :pr:`30`)
 * Added division by :math:`n` to DFT.

--- a/africanus/dft/kernels.py
+++ b/africanus/dft/kernels.py
@@ -29,7 +29,7 @@ def _im_to_vis_impl(image, uvw, lm, frequency, vis_of_im):
 
             # Multiple in frequency for each channel
             for chan in range(frequency.shape[0]):
-                p = real_phase * frequency[chan]
+                p = real_phase * frequency[chan] * 1.0j
 
                 # Our phase input is purely imaginary
                 # so we can can elide a call to exp
@@ -37,7 +37,7 @@ def _im_to_vis_impl(image, uvw, lm, frequency, vis_of_im):
                 # @simon does this really make a difference?
                 # I thought a complex exponential is evaluated
                 # as a sum of sin and cos anyway
-                vis_of_im[row, chan] += np.exp(p)*image[source, chan]/(n+1)
+                vis_of_im[row, chan] += np.exp(p)*image[source, chan]
 
     return vis_of_im
 
@@ -61,7 +61,7 @@ def _vis_to_im_impl(vis, uvw, lm, frequency, im_of_vis):
 
                 im_of_vis[source,
                           chan] += (np.cos(p) * vis[row, chan].real -
-                                    np.sin(p) * vis[row, chan].imag)/(n+1)
+                                    np.sin(p) * vis[row, chan].imag)
                 # Note for the adjoint we don't need the imaginary part
                 # and we can elide the call to exp
 
@@ -92,7 +92,7 @@ im_to_vis_docs = _DFT_DOCSTRING(
 
     .. math::
 
-        {\\Large \\sum_s \\frac{1}{n_s} e^{-2 \\pi i (u l_s + v m_s + w (n_s - 1))} \\cdot I_s }
+        {\\Large \\sum_s e^{-2 \\pi i (u l_s + v m_s + w (n_s - 1))} \\cdot I_s }
 
     """,  # noqa
 
@@ -134,7 +134,7 @@ vis_to_im_docs = _DFT_DOCSTRING(
 
     .. math::
 
-        {\\Large \\sum_k \\frac{1}{n} e^{ 2 \\pi i (u_k l + v_k m + w_k (n - 1))} \\cdot V_k}
+        {\\Large \\sum_k e^{ 2 \\pi i (u_k l + v_k m + w_k (n - 1))} \\cdot V_k}
 
     """,  # noqa
 

--- a/docs/dft-api.rst
+++ b/docs/dft-api.rst
@@ -15,7 +15,9 @@ defined as
 
 where :math:`u,v,w` are data (visibility :math:`V`) space
 coordinates and :math:`l,m,n` are signal (image :math:`I`)
-space coordinates.
+space coordinates. We adopt the convention where we
+absorb the fixed coordinate :math:`n` in the denominator
+into the image.
 Note that the data space coordinates have an implicit
 dependence on frequency and time and that the image
 has an implicit dependence on frequency.
@@ -23,7 +25,7 @@ The discretised form of the DFT can be written as
 
 .. math::
 
-    V(u,v,w) = \sum_s \frac{1}{n_s} e^{-2 \pi i
+    V(u,v,w) = \sum_s e^{-2 \pi i
         (u l_s + v m_s + w (n_s - 1))} \cdot I_s
 
 where :math:`s` labels the source (or pixel) location.
@@ -34,29 +36,27 @@ This can be cast into a matrix equation as follows
     V = R I
 
 where :math:`R` is the operator that maps an
-image to visibility space (note that the
-coordinate :math:`n_s` gets absorbed into
-the definition of :math:`R`). An imaging
-algorithm also requires the adjoint denoted
-:math:`R^\dagger` which is simply the
-complex conjugate transpose of :math:`R`
-(note that this implies there is a similar
-factor of :math:`\frac{1}{n}` involved in
-the definition of :math:`R^\dagger`). The
-dirty image is obtained by applying the
+image to visibility space. This mapping is
+implemented by the :func:`~africanus.dft.im_to_vis`
+function.
+An imaging algorithm also requires the adjoint
+denoted :math:`R^\dagger` which is simply the
+complex conjugate transpose of :math:`R`.
+The dirty image is obtained by applying the
 adjoint operator to the visibilities
 
 .. math::
 
     I^D = R^\dagger V
 
-Note that, since our definition of
-:math:`R^\dagger` contains the factor of
-:math:`\frac{1}{n}`, this notion of the
-dirty image differs from that usually
-encountered in radio astronomy but is
-required to ensure that the operator
-is self-adjoint.
+This is implemented by the
+:func:`~africanus.dft.vis_to_im`
+function.
+Note that an imaging algorithm using these
+operators will actually reconstruct
+:math:`\frac{I}{n}` but that it is trivial
+to obtain :math:`I` since :math:`n` is
+known at each location in the image.
 
 
 Numpy

--- a/tests/test_dft.py
+++ b/tests/test_dft.py
@@ -62,8 +62,8 @@ def test_im_to_vis_zero_w():
     vis_true = np.zeros([nrow, nchan], dtype=np.complex128)
 
 
-    for ch in xrange(nchan):
-        for source in xrange(nsource):
+    for ch in range(nchan):
+        for source in range(nsource):
             vis_true[:, ch] += image[source, ch]*np.exp(
                                  minus_two_pi_over_c*frequency[ch] * 1.0j *
                                  (uvw[:,0]*lm[source,0]+uvw[:,1]*lm[source,1]))

--- a/tests/test_dft.py
+++ b/tests/test_dft.py
@@ -70,7 +70,7 @@ def test_im_to_vis_zero_w():
 
     assert np.allclose(vis, vis_true)
 
-def test_vis_to_im_single_baseline_and_chan():
+def test_im_to_vis_single_baseline_and_chan():
     """
     Here we check that the result is consistent for a single baseline, source and 
     channel. 
@@ -90,7 +90,7 @@ def test_vis_to_im_single_baseline_and_chan():
     vis_true = image*np.exp(minus_two_pi_over_c * frequency * 1.0j *
                             (uvw[:,0]*l + uvw[:,1]*m + uvw[:,2]*(n - 1.0)))
 
-    assert (vis == vis_true)
+    assert np.allclose(vis, vis_true)
 
 
 def test_vis_to_im():
@@ -140,9 +140,8 @@ def test_adjointness():
     gamma1 = np.random.randn(Npix**2, Nchan)
     gamma2 = np.random.randn(Nvis, Nchan)
 
-    LHS = gamma2.T.dot(R(gamma1, uvw, lm, frequency))
-    RHS = RH(gamma2, uvw, lm, frequency).T.dot(gamma1)
-
+    LHS = (gamma2.T.dot(R(gamma1, uvw, lm, frequency))).real
+    RHS = (RH(gamma2, uvw, lm, frequency).T.dot(gamma1)).real
     assert np.all(np.abs(LHS - RHS) < 1e-5)
 
 from africanus.rime.dask import have_requirements

--- a/tests/test_dft.py
+++ b/tests/test_dft.py
@@ -142,7 +142,7 @@ def test_adjointness():
 
     LHS = (gamma2.T.dot(R(gamma1, uvw, lm, frequency))).real
     RHS = (RH(gamma2, uvw, lm, frequency).T.dot(gamma1)).real
-    assert np.all(np.abs(LHS - RHS) < 1e-5)
+    assert np.all(np.abs(LHS - RHS) < 1e-11)
 
 from africanus.rime.dask import have_requirements
 

--- a/tests/test_dft.py
+++ b/tests/test_dft.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import pytest
 
-def test_im_to_vis():
+def test_im_to_vis_phase_centre():
     """
     The simplest test here is to see if a single source at the phase centre
     returns simply the flux everywhere with zero imaginary part
@@ -37,6 +37,61 @@ def test_im_to_vis():
         assert np.all(tmp.real < 1e-13)
         assert np.all(tmp.imag < 1e-13)
 
+def test_im_to_vis_zero_w():
+    """
+    This test checks that the result matches the analytic result in the case when 
+    w = 0 for multiple channels and sources.
+    """
+    from africanus.dft.kernels import im_to_vis
+    from africanus.constants import minus_two_pi_over_c
+    np.random.seed(123)
+    nrow = 100
+    uvw = np.random.random(size=(nrow, 3))
+    uvw[:, 2] = 0.0
+    nchan = 3
+    frequency = np.linspace(1.e9, 2.e9, nchan, endpoint=True)
+    nsource = 5
+    I0 = np.random.randn(nsource)
+    ref_freq = frequency[nchan//2]
+    image = I0[:, None] * (frequency/ref_freq)**(-0.7)
+    l = 0.001 + 0.1*np.random.random(nsource)
+    m = 0.001 + 0.1*np.random.random(nsource)
+    lm = np.vstack((l,m)).T
+    vis = im_to_vis(image, uvw, lm, frequency)
+
+    vis_true = np.zeros([nrow, nchan], dtype=np.complex128)
+
+
+    for ch in xrange(nchan):
+        for source in xrange(nsource):
+            vis_true[:, ch] += image[source, ch]*np.exp(
+                                 minus_two_pi_over_c*frequency[ch] * 1.0j *
+                                 (uvw[:,0]*lm[source,0]+uvw[:,1]*lm[source,1]))
+
+    assert np.allclose(vis, vis_true)
+
+def test_vis_to_im_single_baseline_and_chan():
+    """
+    Here we check that the result is consistent for a single baseline, source and 
+    channel. 
+    """
+    from africanus.dft.kernels import im_to_vis
+    from africanus.constants import minus_two_pi_over_c
+    nrow = 1
+    uvw = np.random.random(size=(nrow, 3))
+    frequency = np.array([1.5e9])
+    l = 0.015
+    m = -0.0123
+    lm = np.array([[l, m]])
+    n = np.sqrt(1 - l**2 - m**2)
+    image = np.array([[1.0]])
+    vis = im_to_vis(image, uvw, lm, frequency)
+
+    vis_true = image*np.exp(minus_two_pi_over_c * frequency * 1.0j *
+                            (uvw[:,0]*l + uvw[:,1]*m + uvw[:,2]*(n - 1.0)))
+
+    assert (vis == vis_true)
+
 
 def test_vis_to_im():
     """
@@ -53,7 +108,6 @@ def test_vis_to_im():
     x = np.linspace(-0.1, 0.1, npix)
     ll, mm = np.meshgrid(x, x)
     lm = np.vstack((ll.flatten(), mm.flatten())).T
-    n = np.sqrt(1 - lm[:, 0]**2 - lm[:, 1]**2)
     wsum = 1.0
 
     frequency = np.linspace(1.0, 2.0, nchan, endpoint=True)
@@ -61,7 +115,7 @@ def test_vis_to_im():
     image = vis_to_im(vis, uvw, lm, frequency)
 
     for i in range(nchan):
-        assert np.all(image[:, i] == wsum/n)
+        assert np.all(image[:, i] == wsum)
 
 
 def test_adjointness():


### PR DESCRIPTION
Fixes https://github.com/ska-sa/codex-africanus/issues/34

I also removed the division by n in the dft since this unnecessarily complicates things (e.g. makes the PSF direction dependent in a trivial way). 