### PR TITLE
Use 2D filters by default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
+* Use 2D filters by default (:pr:`37`)
 * Fixed bug in im_to_vis. Added more tests for im_to_vis.
   Removed division by :math:`n` since it is trivial to reinstate
   after the fact. (:pr:`34`)

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -14,7 +14,7 @@ ConvolutionFilter = collections.namedtuple("ConvolutionFilter",
                                             'no_taps', 'filter_taps'])
 """
 :class:`collections.namedtuple` containing attributes
-defining a Convolution Filter. A namedtuple is used
+defining a 2D Convolution Filter. A namedtuple is used
 because they're easier to use when using
 ``nopython`` mode in :mod:`numba`.
 
@@ -40,13 +40,13 @@ because they're easier to use when using
 
 .. attribute:: filter_taps
 
-    Filter taps
+    2D filter taps with shape (v, u)
 """
 
 
 def convolution_filter(half_support, oversampling_factor, filter_type):
     """
-    Create a 1D Convolution Filter suitable
+    Create a 2D Convolution Filter suitable
     for use with gridding and degridding functions.
 
     Parameters
@@ -88,6 +88,9 @@ def convolution_filter(half_support, oversampling_factor, filter_type):
         filter_taps /= np.pi*taps_eps
     else:
         raise ValueError("Expected one of 'box','sinc' or 'gaussian_sinc'")
+
+    # Expand filter taps to 2D
+    filter_taps = np.outer(filter_taps, filter_taps)
 
     return ConvolutionFilter(half_support, oversampling_factor,
                              full_sup_wo_padding, full_sup,

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -72,13 +72,13 @@ def _nb_grid(vis, uvw, flags, weights, ref_wave,
 
             # Iterate over v/y
             for conv_v in filter_index:
-                v_tap = cf.filter_taps[conv_v*cf.oversample + frac_v]
+                v_idx = conv_v*cf.oversample + frac_v
                 grid_v = disc_v + conv_v + ny // 2
 
                 # Iterate over u/x
                 for conv_u in filter_index:
-                    u_tap = cf.filter_taps[conv_u*cf.oversample + frac_u]
-                    conv_weight = v_tap*u_tap
+                    u_idx = conv_u*cf.oversample + frac_u
+                    conv_weight = cf.filter_taps[v_idx, u_idx]
                     grid_u = disc_u + conv_u + nx // 2
 
                     for c in range(flat_corrs):      # correlation
@@ -242,13 +242,15 @@ def _degrid(grid, uvw, weights, ref_wave, convolution_filter):
             frac_u = int(base_frac_u*cf.oversample)
             frac_v = int(base_frac_v*cf.oversample)
 
+            # Iterate over v/y
             for conv_v in filter_index:
-                v_tap = cf.filter_taps[conv_v*cf.oversample + frac_v]
+                v_idx = conv_v*cf.oversample + frac_v
                 grid_v = disc_v + conv_v + ny // 2
 
+                # Iterate over u/x
                 for conv_u in filter_index:
-                    u_tap = cf.filter_taps[conv_u*cf.oversample + frac_u]
-                    conv_weight = v_tap * u_tap
+                    u_idx = conv_u*cf.oversample + frac_u
+                    conv_weight = cf.filter_taps[v_idx, u_idx]
                     grid_u = disc_u + conv_u + nx // 2
 
                     # Correlation


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
