### PR TITLE
Improve optional dependencies

### DIFF
--- a/africanus/conftest.py
+++ b/africanus/conftest.py
@@ -1,0 +1,9 @@
+# content of conftest.py
+def pytest_configure(config):
+    import sys
+    sys._called_from_test = True
+
+
+def pytest_unconfigure(config):
+    import sys
+    del sys._called_from_test

--- a/africanus/dft/dask.py
+++ b/africanus/dft/dask.py
@@ -10,62 +10,60 @@ from .kernels import im_to_vis_docs, vis_to_im_docs
 from .kernels import im_to_vis as np_im_to_vis
 from .kernels import vis_to_im as np_vis_to_im
 
-from ..util.docs import on_rtd, doc_tuple_to_str, mod_docs
-from ..util.requirements import have_packages, MissingPackageException
+from ..util.docs import doc_tuple_to_str
+from ..util.requirements import requires_optional
 
-_package_requirements = ('dask.array',)
-have_requirements = have_packages(*_package_requirements)
+import numpy as np
 
-if not have_requirements or on_rtd():
-    def im_to_vis(image, uvw, lm, frequency, dtype=None):
-        raise MissingPackageException(*_package_requirements)
-
-    def vis_to_im(vis, uvw, lm, frequency, dtype=None):
-        raise MissingPackageException(*_package_requirements)
-else:
-    import numpy as np
+try:
     import dask.array as da
+except ImportError:
+    pass
 
-    def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
-        """ Dask wrapper for phase_delay function """
-        @wraps(np_im_to_vis)
-        def _wrapper(image, uvw, lm, frequency, dtype_):
-            return np_im_to_vis(image[0], uvw[0], lm[0][0],
-                                frequency, dtype=dtype_)
-        if lm.chunks[0][0] != lm.shape[0]:
-            raise ValueError("lm chunks must match lm shape "
-                             "on first axis")
-        if image.chunks[0][0] != image.shape[0]:
-            raise ValueError("Image chunks must match image "
-                             "shape on first axis")
-        if image.chunks[0][0] != lm.chunks[0][0]:
-            raise ValueError("Image chunks and lm chunks must "
-                             "match on first axis")
-        return da.core.atop(_wrapper, ("row", "chan"),
-                            image, ("source", "chan"),
-                            uvw, ("row", "(u,v,w)"),
-                            lm, ("source", "(l,m)"),
-                            frequency, ("chan",),
-                            dtype=dtype,
-                            dtype_=dtype)
 
-    def vis_to_im(vis, uvw, lm, frequency, dtype=np.float64):
-        """ Dask wrapper for phase_delay_adjoint function """
-        @wraps(np_vis_to_im)
-        def _wrapper(vis, uvw, lm, frequency, dtype_):
-            return np_vis_to_im(vis, uvw[0], lm[0], frequency,
-                                dtype=dtype_)[None, :]
+@requires_optional('dask.array')
+def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
+    """ Dask wrapper for phase_delay function """
+    @wraps(np_im_to_vis)
+    def _wrapper(image, uvw, lm, frequency, dtype_):
+        return np_im_to_vis(image[0], uvw[0], lm[0][0],
+                            frequency, dtype=dtype_)
+    if lm.chunks[0][0] != lm.shape[0]:
+        raise ValueError("lm chunks must match lm shape "
+                         "on first axis")
+    if image.chunks[0][0] != image.shape[0]:
+        raise ValueError("Image chunks must match image "
+                         "shape on first axis")
+    if image.chunks[0][0] != lm.chunks[0][0]:
+        raise ValueError("Image chunks and lm chunks must "
+                         "match on first axis")
+    return da.core.atop(_wrapper, ("row", "chan"),
+                        image, ("source", "chan"),
+                        uvw, ("row", "(u,v,w)"),
+                        lm, ("source", "(l,m)"),
+                        frequency, ("chan",),
+                        dtype=dtype,
+                        dtype_=dtype)
 
-        ims = da.core.atop(_wrapper, ("row", "source", "chan"),
-                           vis, ("row", "chan"),
-                           uvw, ("row", "(u,v,w)"),
-                           lm, ("source", "(l,m)"),
-                           frequency, ("chan",),
-                           adjust_chunks={"row": 1},
-                           dtype=dtype,
-                           dtype_=dtype)
 
-        return ims.sum(axis=0)
+@requires_optional('dask.array')
+def vis_to_im(vis, uvw, lm, frequency, dtype=np.float64):
+    """ Dask wrapper for phase_delay_adjoint function """
+    @wraps(np_vis_to_im)
+    def _wrapper(vis, uvw, lm, frequency, dtype_):
+        return np_vis_to_im(vis, uvw[0], lm[0], frequency,
+                            dtype=dtype_)[None, :]
+
+    ims = da.core.atop(_wrapper, ("row", "source", "chan"),
+                       vis, ("row", "chan"),
+                       uvw, ("row", "(u,v,w)"),
+                       lm, ("source", "(l,m)"),
+                       frequency, ("chan",),
+                       adjust_chunks={"row": 1},
+                       dtype=dtype,
+                       dtype_=dtype)
+
+    return ims.sum(axis=0)
 
 
 im_to_vis.__doc__ = doc_tuple_to_str(im_to_vis_docs,

--- a/africanus/dft/tests/test_dft.py
+++ b/africanus/dft/tests/test_dft.py
@@ -7,8 +7,6 @@ import numpy as np
 
 import pytest
 
-from africanus.rime.dask import have_requirements
-
 
 def test_im_to_vis_phase_centre():
     """
@@ -152,9 +150,8 @@ def test_adjointness():
     assert np.all(np.abs(LHS - RHS) < 1e-11)
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 def test_im_to_vis_dask():
-    import dask.array as da
+    da = pytest.importorskip("dask.array")
     from africanus.dft.kernels import im_to_vis as np_im_to_vis
     from africanus.dft.dask import im_to_vis as dask_im_to_vis
 
@@ -187,9 +184,8 @@ def test_im_to_vis_dask():
     assert np.allclose(vis, vis_dask)
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 def test_vis_to_im_dask():
-    import dask.array as da
+    da = pytest.importorskip("dask.array")
     from africanus.dft.kernels import vis_to_im as np_vis_to_im
     from africanus.dft.dask import vis_to_im as dask_vis_to_im
 

--- a/africanus/gridding/simple/tests/test_simple_gridder.py
+++ b/africanus/gridding/simple/tests/test_simple_gridder.py
@@ -8,7 +8,6 @@ from itertools import product
 import numpy as np
 import pytest
 
-from africanus.gridding.simple.dask import have_requirements
 from africanus.constants import c as lightspeed
 from africanus.gridding.util import estimate_cell_size
 
@@ -209,12 +208,11 @@ def test_psf_subtraction(plot):
     assert np.allclose(centre_psf, centre_dirty, rtol=1e-64)
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 def test_dask_degridder_gridder():
     from africanus.filters import convolution_filter
     from africanus.gridding.simple.dask import grid, degrid
 
-    import dask.array as da
+    da = pytest.importorskip('dask.array')
 
     row = 100
     chan = 16

--- a/africanus/rime/beam_cubes.py
+++ b/africanus/rime/beam_cubes.py
@@ -9,10 +9,17 @@ from __future__ import unicode_literals
 from itertools import product
 
 import numpy as np
-from scipy import interpolate
-from scipy.ndimage import interpolation
+
+try:
+    from scipy import interpolate
+    from scipy.ndimage import interpolation
+except ImportError:
+    pass
+
+from ..util.requirements import requires_optional
 
 
+@requires_optional("scipy")
 def beam_cube_dde(beam, coords, l_grid, m_grid, freq_grid,
                   spline_order=1, mode='nearest'):
     """

--- a/africanus/rime/dask.py
+++ b/africanus/rime/dask.py
@@ -18,237 +18,229 @@ from .predict import predict_vis as np_predict_vis
 from .zernike import zernike_dde as np_zernike_dde
 
 
-from ..util.docs import on_rtd, doc_tuple_to_str, mod_docs
-from ..util.requirements import have_packages, MissingPackageException
+from ..util.docs import doc_tuple_to_str, mod_docs
+from ..util.requirements import requires_optional
 
-_package_requirements = ('dask.array', 'toolz')
-have_requirements = have_packages(*_package_requirements)
+import numpy as np
 
-if not have_requirements or on_rtd():
-    def phase_delay(uvw, lm, frequency, dtype=None):
-        raise MissingPackageException(*_package_requirements)
-
-    def parallactic_angles(times, antenna_positions, field_centre, **kwargs):
-        raise MissingPackageException(*_package_requirements)
-
-    def feed_rotation(parallactic_angles, feed_type=None):
-        raise MissingPackageException(*_package_requirements)
-
-    def transform_sources(lm, parallactic_angles, pointing_errors,
-                          antenna_scaling, dtype=None):
-        raise MissingPackageException(*_package_requirements)
-
-    def beam_cube_dde(beam, coords, l_grid, m_grid, freq_grid,
-                      spline_order=1, mode='nearest'):
-        raise MissingPackageException(*_package_requirements)
-
-    def zernike_dde(coords, coeffs, noll_index):
-        raise MissingPackageException(*_package_requirements)
-
-    def predict_vis(time_index, antenna1, antenna2,
-                    ant1_jones, ant2_jones, row_jones,
-                    g1_jones, g2_jones):
-        raise MissingPackageException(*_package_requirements)
-
-else:
-    import numpy as np
+try:
     import dask.array as da
+except ImportError:
+    pass
 
+try:
+    import cytoolz as toolz
+except ImportError:
     try:
-        import cytoolz as toolz
-    except ImportError:
         import toolz
+    except ImportError:
+        pass
 
-    def phase_delay(uvw, lm, frequency, dtype=np.complex128):
-        """ Dask wrapper for phase_delay function """
-        @wraps(np_phase_delay)
-        def _wrapper(uvw, lm, frequency, dtype_):
-            return np_phase_delay(uvw[0], lm[0], frequency, dtype=dtype_)
 
-        return da.core.atop(_wrapper, ("source", "row", "chan"),
-                            uvw, ("row", "(u,v,w)"),
-                            lm, ("source", "(l,m)"),
-                            frequency, ("chan",),
-                            dtype=dtype,
-                            dtype_=dtype)
+@requires_optional('dask.array')
+def phase_delay(uvw, lm, frequency, dtype=np.complex128):
+    """ Dask wrapper for phase_delay function """
+    @wraps(np_phase_delay)
+    def _wrapper(uvw, lm, frequency, dtype_):
+        return np_phase_delay(uvw[0], lm[0], frequency, dtype=dtype_)
 
-    def parallactic_angles(times, antenna_positions, field_centre, **kwargs):
-        @wraps(np_parangles)
-        def _wrapper(t, ap, fc, **kw):
-            return np_parangles(t, ap[0], fc[0], **kwargs)
+    return da.core.atop(_wrapper, ("source", "row", "chan"),
+                        uvw, ("row", "(u,v,w)"),
+                        lm, ("source", "(l,m)"),
+                        frequency, ("chan",),
+                        dtype=dtype,
+                        dtype_=dtype)
 
-        return da.core.atop(_wrapper, ("time", "ant"),
-                            times, ("time",),
-                            antenna_positions, ("ant", "xyz"),
-                            field_centre, ("fc",),
-                            dtype=times.dtype,
-                            **kwargs)
 
-    def feed_rotation(parallactic_angles, feed_type):
-        pa_dims = tuple("pa-%d" % i for i in range(parallactic_angles.ndim))
-        corr_dims = ('corr-1', 'corr-2')
+@requires_optional('dask.array')
+def parallactic_angles(times, antenna_positions, field_centre, **kwargs):
+    @wraps(np_parangles)
+    def _wrapper(t, ap, fc, **kw):
+        return np_parangles(t, ap[0], fc[0], **kwargs)
 
-        if parallactic_angles.dtype == np.float32:
-            dtype = np.complex64
-        elif parallactic_angles.dtype == np.float64:
-            dtype = np.complex128
-        else:
-            raise ValueError("parallactic_angles have "
-                             "non-floating point dtype")
+    return da.core.atop(_wrapper, ("time", "ant"),
+                        times, ("time",),
+                        antenna_positions, ("ant", "xyz"),
+                        field_centre, ("fc",),
+                        dtype=times.dtype,
+                        **kwargs)
 
-        return da.core.atop(np_feed_rotation, pa_dims + corr_dims,
-                            parallactic_angles, pa_dims,
-                            feed_type=feed_type,
-                            new_axes={'corr-1': 2, 'corr-2': 2},
-                            dtype=dtype)
 
-    def transform_sources(lm, parallactic_angles, pointing_errors,
-                          antenna_scaling, frequency, dtype=None):
+@requires_optional('dask.array')
+def feed_rotation(parallactic_angles, feed_type):
+    pa_dims = tuple("pa-%d" % i for i in range(parallactic_angles.ndim))
+    corr_dims = ('corr-1', 'corr-2')
 
-        @wraps(np_transform_sources)
-        def _wrapper(lm, parallactic_angles, pointing_errors,
-                     antenna_scaling, frequency, dtype_):
-            return np_transform_sources(lm[0], parallactic_angles,
-                                        pointing_errors[0], antenna_scaling,
-                                        frequency, dtype=dtype_)
+    if parallactic_angles.dtype == np.float32:
+        dtype = np.complex64
+    elif parallactic_angles.dtype == np.float64:
+        dtype = np.complex128
+    else:
+        raise ValueError("parallactic_angles have "
+                         "non-floating point dtype")
 
-        if dtype is None:
-            dtype = np.float64
+    return da.core.atop(np_feed_rotation, pa_dims + corr_dims,
+                        parallactic_angles, pa_dims,
+                        feed_type=feed_type,
+                        new_axes={'corr-1': 2, 'corr-2': 2},
+                        dtype=dtype)
 
-        return da.core.atop(_wrapper, ("comp", "src", "time", "ant", "chan"),
-                            lm, ("src", "lm"),
-                            parallactic_angles, ("time", "ant"),
-                            pointing_errors, ("time", "ant", "lm"),
-                            antenna_scaling, ("ant", "chan"),
-                            frequency, ("chan",),
-                            new_axes={"comp": 3},
-                            dtype=dtype,
-                            dtype_=dtype)
 
-    def beam_cube_dde(beam, coords, l_grid, m_grid, freq_grid,
-                      spline_order=1, mode='nearest'):
+@requires_optional('dask.array')
+def transform_sources(lm, parallactic_angles, pointing_errors,
+                      antenna_scaling, frequency, dtype=None):
 
-        @wraps(np_beam_cude_dde)
-        def _wrapper(beam, coords, l_grid, m_grid, freq_grid,
-                     spline_order=1, mode='nearest'):
-            return np_beam_cude_dde(beam[0][0][0], coords[0],
-                                    l_grid[0], m_grid[0], freq_grid[0],
-                                    spline_order=spline_order, mode=mode)
+    @wraps(np_transform_sources)
+    def _wrapper(lm, parallactic_angles, pointing_errors,
+                 antenna_scaling, frequency, dtype_):
+        return np_transform_sources(lm[0], parallactic_angles,
+                                    pointing_errors[0], antenna_scaling,
+                                    frequency, dtype=dtype_)
 
-        coord_shapes = coords.shape[1:]
-        corr_shapes = beam.shape[3:]
-        corr_dims = tuple("corr-%d" % i for i in range(len(corr_shapes)))
-        coord_dims = tuple("coord-%d" % i for i in range(len(coord_shapes)))
+    if dtype is None:
+        dtype = np.float64
 
-        beam_dims = ("beam_lw", "beam_mh", "beam_nud") + corr_dims
+    return da.core.atop(_wrapper, ("comp", "src", "time", "ant", "chan"),
+                        lm, ("src", "lm"),
+                        parallactic_angles, ("time", "ant"),
+                        pointing_errors, ("time", "ant", "lm"),
+                        antenna_scaling, ("ant", "chan"),
+                        frequency, ("chan",),
+                        new_axes={"comp": 3},
+                        dtype=dtype,
+                        dtype_=dtype)
 
-        return da.core.atop(_wrapper, coord_dims + corr_dims,
-                            beam, beam_dims,
-                            coords, ("coords",) + coord_dims,
-                            l_grid, ("beam_lw",),
-                            m_grid, ("beam_mh",),
-                            freq_grid, ("beam_nud",),
-                            spline_order=spline_order,
-                            mode=mode,
-                            dtype=beam.dtype)
 
-    def zernike_dde(coords, coeffs, noll_index):
-        ncorrs = len(coeffs.shape[2:-1])
-        corr_dims = tuple("corr-%d" % i for i in range(ncorrs))
+@requires_optional('dask.array')
+def beam_cube_dde(beam, coords, l_grid, m_grid, freq_grid,
+                  spline_order=1, mode='nearest'):
 
-        @wraps(np_zernike_dde)
-        def _wrapper(coords, coeffs, noll_index):
-            # coords loses "three" dim
-            # coeffs loses "poly" dim
-            # noll_index loses "poly" dim
-            return np_zernike_dde(coords[0], coeffs[0], noll_index[0])
+    @wraps(np_beam_cude_dde)
+    def _wrapper(beam, coords, l_grid, m_grid, freq_grid,
+                 spline_order=1, mode='nearest'):
+        return np_beam_cude_dde(beam[0][0][0], coords[0],
+                                l_grid[0], m_grid[0], freq_grid[0],
+                                spline_order=spline_order, mode=mode)
 
-        return da.core.atop(_wrapper,
-                            ("source", "time", "ant", "chan") + corr_dims,
-                            coords,
-                            ("three", "source", "time", "ant", "chan"),
-                            coeffs,
-                            ("ant", "chan") + corr_dims + ("poly",),
-                            noll_index,
-                            ("ant", "chan") + corr_dims + ("poly",),
-                            dtype=coeffs.dtype)
+    coord_shapes = coords.shape[1:]
+    corr_shapes = beam.shape[3:]
+    corr_dims = tuple("corr-%d" % i for i in range(len(corr_shapes)))
+    coord_dims = tuple("coord-%d" % i for i in range(len(coord_shapes)))
 
-    def predict_vis(time_index, antenna1, antenna2,
-                    ant1_jones, ant2_jones, row_jones,
-                    g1_jones, g2_jones):
+    beam_dims = ("beam_lw", "beam_mh", "beam_nud") + corr_dims
 
-        @wraps(np_predict_vis)
-        def _wrapper(time_index, antenna1, antenna2,
-                     ant1_jones, ant2_jones, row_jones,
-                     g1_jones, g2_jones):
+    return da.core.atop(_wrapper, coord_dims + corr_dims,
+                        beam, beam_dims,
+                        coords, ("coords",) + coord_dims,
+                        l_grid, ("beam_lw",),
+                        m_grid, ("beam_mh",),
+                        freq_grid, ("beam_nud",),
+                        spline_order=spline_order,
+                        mode=mode,
+                        dtype=beam.dtype)
 
-            # Normalise the time index
-            time_index -= time_index.min()
 
-            return np_predict_vis(time_index, antenna1, antenna2,
-                                  ant1_jones[0][0], ant2_jones[0][0],
-                                  row_jones[0], g1_jones[0], g2_jones[0])
+@requires_optional('dask.array')
+def zernike_dde(coords, coeffs, noll_index):
+    ncorrs = len(coeffs.shape[2:-1])
+    corr_dims = tuple("corr-%d" % i for i in range(ncorrs))
 
-        if ant1_jones.shape[2] != ant1_jones.chunks[2][0]:
-            raise ValueError("Subdivision of antenna dimension into "
-                             "multiple chunks is not supported.")
+    @wraps(np_zernike_dde)
+    def _wrapper(coords, coeffs, noll_index):
+        # coords loses "three" dim
+        # coeffs loses "poly" dim
+        # noll_index loses "poly" dim
+        return np_zernike_dde(coords[0], coeffs[0], noll_index[0])
 
-        if len(ant1_jones.chunks[1]) != len(time_index.chunks[0]):
-            raise ValueError("Number of row chunks (%s) does not equal "
-                             "number of time chunks (%s)." %
-                             (time_index.chunks[0], ant1_jones.chunks[1]))
+    return da.core.atop(_wrapper,
+                        ("source", "time", "ant", "chan") + corr_dims,
+                        coords,
+                        ("three", "source", "time", "ant", "chan"),
+                        coeffs,
+                        ("ant", "chan") + corr_dims + ("poly",),
+                        noll_index,
+                        ("ant", "chan") + corr_dims + ("poly",),
+                        dtype=coeffs.dtype)
 
-        # Generate strings for the correlation dimensions
-        cdims = tuple("corr-%d" % i for i in range(len(row_jones.shape[3:])))
-        ajones_dims = ("src", "row", "ant", "chan") + cdims
 
-        # In the case predict_vis, the "row" and "time" dimensions
-        # are intimately related -- a contiguous series of rows
-        # are related to a contiguous series of timesteps.
-        # This means that the number of chunks of these
-        # two dimensions must match even though the chunk sizes may not.
-        # da.core.atop insists on matching chunk sizes.
-        # For this reason, we use the lower level da.core.top and
-        # substitute "row" for "time" in arrays such as ant1_jones
-        # and g1_jones.
-        token = da.core.tokenize(time_index, antenna1, antenna2,
-                                 ant1_jones, ant2_jones, row_jones,
-                                 g1_jones, g2_jones)
-        name = "-".join(("predict_vis", token))
-        dsk = da.core.top(_wrapper, name, ("row", "chan") + cdims,
-                          time_index.name, ("row",),
-                          antenna1.name, ("row",),
-                          antenna2.name, ("row",),
-                          ant1_jones.name, ajones_dims,
-                          ant2_jones.name, ajones_dims,
-                          row_jones.name, ("src", "row", "chan") + cdims,
-                          g1_jones.name, ("row", "ant", "chan") + cdims,
-                          g2_jones.name, ("row", "ant", "chan") + cdims,
-                          numblocks={
-                                time_index.name: time_index.numblocks,
-                                antenna1.name: antenna1.numblocks,
-                                antenna2.name: antenna2.numblocks,
-                                ant1_jones.name: ant1_jones.numblocks,
-                                ant2_jones.name: ant2_jones.numblocks,
-                                row_jones.name: row_jones.numblocks,
-                                g1_jones.name: g1_jones.numblocks,
-                                g2_jones.name: g2_jones.numblocks,
-                            })
+@requires_optional('dask.array')
+def predict_vis(time_index, antenna1, antenna2,
+                ant1_jones, ant2_jones, row_jones,
+                g1_jones, g2_jones):
 
-        # Merge input graphs into the top graph
-        dsk = toolz.merge(dsk, *(a.__dask_graph__() for a in (time_index,
-                                                              antenna1,
-                                                              antenna2,
-                                                              ant1_jones,
-                                                              ant2_jones,
-                                                              row_jones,
-                                                              g1_jones,
-                                                              g2_jones)))
+    @wraps(np_predict_vis)
+    def _wrapper(time_index, antenna1, antenna2,
+                 ant1_jones, ant2_jones, row_jones,
+                 g1_jones, g2_jones):
 
-        # We can infer output chunk sizes from row_jones
-        chunks = row_jones.chunks[1:]
+        # Normalise the time index
+        time_index -= time_index.min()
 
-        return da.Array(dsk, name, chunks, dtype=ant1_jones.dtype)
+        return np_predict_vis(time_index, antenna1, antenna2,
+                              ant1_jones[0][0], ant2_jones[0][0],
+                              row_jones[0], g1_jones[0], g2_jones[0])
+
+    if ant1_jones.shape[2] != ant1_jones.chunks[2][0]:
+        raise ValueError("Subdivision of antenna dimension into "
+                         "multiple chunks is not supported.")
+
+    if len(ant1_jones.chunks[1]) != len(time_index.chunks[0]):
+        raise ValueError("Number of row chunks (%s) does not equal "
+                         "number of time chunks (%s)." %
+                         (time_index.chunks[0], ant1_jones.chunks[1]))
+
+    # Generate strings for the correlation dimensions
+    cdims = tuple("corr-%d" % i for i in range(len(row_jones.shape[3:])))
+    ajones_dims = ("src", "row", "ant", "chan") + cdims
+
+    # In the case predict_vis, the "row" and "time" dimensions
+    # are intimately related -- a contiguous series of rows
+    # are related to a contiguous series of timesteps.
+    # This means that the number of chunks of these
+    # two dimensions must match even though the chunk sizes may not.
+    # da.core.atop insists on matching chunk sizes.
+    # For this reason, we use the lower level da.core.top and
+    # substitute "row" for "time" in arrays such as ant1_jones
+    # and g1_jones.
+    token = da.core.tokenize(time_index, antenna1, antenna2,
+                             ant1_jones, ant2_jones, row_jones,
+                             g1_jones, g2_jones)
+    name = "-".join(("predict_vis", token))
+    dsk = da.core.top(_wrapper, name, ("row", "chan") + cdims,
+                      time_index.name, ("row",),
+                      antenna1.name, ("row",),
+                      antenna2.name, ("row",),
+                      ant1_jones.name, ajones_dims,
+                      ant2_jones.name, ajones_dims,
+                      row_jones.name, ("src", "row", "chan") + cdims,
+                      g1_jones.name, ("row", "ant", "chan") + cdims,
+                      g2_jones.name, ("row", "ant", "chan") + cdims,
+                      numblocks={
+                            time_index.name: time_index.numblocks,
+                            antenna1.name: antenna1.numblocks,
+                            antenna2.name: antenna2.numblocks,
+                            ant1_jones.name: ant1_jones.numblocks,
+                            ant2_jones.name: ant2_jones.numblocks,
+                            row_jones.name: row_jones.numblocks,
+                            g1_jones.name: g1_jones.numblocks,
+                            g2_jones.name: g2_jones.numblocks,
+                        })
+
+    # Merge input graphs into the top graph
+    dsk = toolz.merge(dsk, *(a.__dask_graph__() for a in (time_index,
+                                                          antenna1,
+                                                          antenna2,
+                                                          ant1_jones,
+                                                          ant2_jones,
+                                                          row_jones,
+                                                          g1_jones,
+                                                          g2_jones)))
+
+    # We can infer output chunk sizes from row_jones
+    chunks = row_jones.chunks[1:]
+
+    return da.Array(dsk, name, chunks, dtype=ant1_jones.dtype)
+
 
 phase_delay.__doc__ = doc_tuple_to_str(phase_delay_docs,
                                        [(":class:`numpy.ndarray`",

--- a/africanus/rime/parangles.py
+++ b/africanus/rime/parangles.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import numpy as np
 
 from ..util.requirements import requires_optional
-from ..util.docs import on_rtd
 
 _discovered_backends = []
 _standard_backends = ['casa', 'astropy']

--- a/africanus/rime/parangles.py
+++ b/africanus/rime/parangles.py
@@ -6,96 +6,91 @@ from __future__ import print_function
 
 import numpy as np
 
-from ..util.requirements import have_packages, MissingPackageException
+from ..util.requirements import requires_optional
 from ..util.docs import on_rtd
 
 _discovered_backends = []
 _standard_backends = ['casa', 'astropy']
 
-_casa_requirements = ('pyrap.measures', 'pyrap.quanta')
-have_casa_requirements = have_packages(*_casa_requirements)
-
-if not have_casa_requirements or on_rtd():
-    def casa_parallactic_angles(times, antenna_positions, field_centre):
-        raise MissingPackageException(*_casa_requirements)
-else:
-    _discovered_backends.append('casa')
-
+try:
     import pyrap.measures
     import pyrap.quanta as pq
-
+except ImportError:
+    pass
+else:
+    _discovered_backends.append('casa')
     # Create a measures server
     meas_serv = pyrap.measures.measures()
 
-    def casa_parallactic_angles(times, antenna_positions, field_centre):
-        """
-        Computes parallactic angles per timestep for the given
-        reference antenna position and field centre.
-        """
-
-        # Create direction measure for the zenith
-        zenith = meas_serv.direction('AZELGEO', '0deg', '90deg')
-
-        # Create position measures for each antenna
-        reference_positions = [meas_serv.position(
-                                    'itrf',
-                                    *(pq.quantity(x, 'm') for x in pos))
-                               for pos in antenna_positions]
-
-        # Compute field centre in radians
-        fc_rad = meas_serv.direction('J2000', *(pq.quantity(f, 'rad')
-                                                for f in field_centre))
-
-        return np.asarray([
-            # Set current time as the reference frame
-            meas_serv.do_frame(meas_serv.epoch("UTC", pq.quantity(t, "s")))
-            and
-            [   # Set antenna position as the reference frame
-                meas_serv.do_frame(rp)
-                and
-                meas_serv.posangle(fc_rad, zenith).get_value("rad")
-                for rp in reference_positions
-            ]
-            for t in times])
-
-_astropy_requirements = ('astropy',)
-have_astropy_requirements = have_packages(*_astropy_requirements)
-
-if not have_astropy_requirements or on_rtd():
-    def astropy_parallactic_angles(times, antenna_positions, field_centre):
-        raise MissingPackageException(*_astropy_requirements)
-else:
-    _discovered_backends.append('astropy')
-
+try:
     from astropy.coordinates import (EarthLocation, SkyCoord,
                                      AltAz, CIRS)
     from astropy.time import Time
     from astropy import units
+except ImportError:
+    pass
+else:
+    _discovered_backends.append('astropy')
 
-    def astropy_parallactic_angles(times, antenna_positions, field_centre):
-        """
-        Computes parallactic angles per timestep for the given
-        reference antenna position and field centre.
-        """
-        ap = antenna_positions
-        fc = field_centre
 
-        # Convert from MJD second to MJD
-        times = Time(times / 86400.00, format='mjd', scale='utc')
+@requires_optional('pyrap.measures', 'pyrap.quanta')
+def casa_parallactic_angles(times, antenna_positions, field_centre):
+    """
+    Computes parallactic angles per timestep for the given
+    reference antenna position and field centre.
+    """
 
-        ap = EarthLocation.from_geocentric(
-            ap[:, 0], ap[:, 1], ap[:, 2], unit='m')
-        fc = SkyCoord(ra=fc[0], dec=fc[1], unit=units.rad, frame='fk5')
-        pole = SkyCoord(ra=0, dec=90, unit=units.deg, frame='fk5')
+    # Create direction measure for the zenith
+    zenith = meas_serv.direction('AZELGEO', '0deg', '90deg')
 
-        cirs_frame = CIRS(obstime=times)
-        pole_cirs = pole.transform_to(cirs_frame)
-        fc_cirs = fc.transform_to(cirs_frame)
+    # Create position measures for each antenna
+    reference_positions = [meas_serv.position(
+                                'itrf',
+                                *(pq.quantity(x, 'm') for x in pos))
+                           for pos in antenna_positions]
 
-        altaz_frame = AltAz(location=ap[None, :], obstime=times[:, None])
-        pole_altaz = pole_cirs[:, None].transform_to(altaz_frame)
-        fc_altaz = fc_cirs[:, None].transform_to(altaz_frame)
-        return fc_altaz.position_angle(pole_altaz)
+    # Compute field centre in radians
+    fc_rad = meas_serv.direction('J2000', *(pq.quantity(f, 'rad')
+                                            for f in field_centre))
+
+    return np.asarray([
+        # Set current time as the reference frame
+        meas_serv.do_frame(meas_serv.epoch("UTC", pq.quantity(t, "s")))
+        and
+        [   # Set antenna position as the reference frame
+            meas_serv.do_frame(rp)
+            and
+            meas_serv.posangle(fc_rad, zenith).get_value("rad")
+            for rp in reference_positions
+        ]
+        for t in times])
+
+
+@requires_optional('astropy')
+def astropy_parallactic_angles(times, antenna_positions, field_centre):
+    """
+    Computes parallactic angles per timestep for the given
+    reference antenna position and field centre.
+    """
+    ap = antenna_positions
+    fc = field_centre
+
+    # Convert from MJD second to MJD
+    times = Time(times / 86400.00, format='mjd', scale='utc')
+
+    ap = EarthLocation.from_geocentric(
+        ap[:, 0], ap[:, 1], ap[:, 2], unit='m')
+    fc = SkyCoord(ra=fc[0], dec=fc[1], unit=units.rad, frame='fk5')
+    pole = SkyCoord(ra=0, dec=90, unit=units.deg, frame='fk5')
+
+    cirs_frame = CIRS(obstime=times)
+    pole_cirs = pole.transform_to(cirs_frame)
+    fc_cirs = fc.transform_to(cirs_frame)
+
+    altaz_frame = AltAz(location=ap[None, :], obstime=times[:, None])
+    pole_altaz = pole_cirs[:, None].transform_to(altaz_frame)
+    fc_altaz = fc_cirs[:, None].transform_to(altaz_frame)
+    return fc_altaz.position_angle(pole_altaz)
 
 
 def parallactic_angles(times, antenna_positions, field_centre, **kwargs):

--- a/africanus/rime/tests/test_beams.py
+++ b/africanus/rime/tests/test_beams.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import pytest
 
 
 def rf(*a, **kw):
@@ -37,7 +38,7 @@ def test_transform_sources():
 
 
 def test_dask_transform_sources():
-    import dask.array as da
+    da = pytest.importorskip("dask.array")
 
     from africanus.rime.dask import transform_sources as dask_xform_src
     from africanus.rime import transform_sources as np_xform_src
@@ -73,7 +74,6 @@ def test_dask_transform_sources():
 
 
 def test_beam_cube():
-
     beam_lw = 10
     beam_mh = 10
     beam_nud = 10
@@ -108,6 +108,8 @@ def test_beam_cube():
 
 
 def test_dask_beam_cube():
+    da = pytest.importorskip('dask.array')
+
     beam_lw = 10
     beam_mh = 10
     beam_nud = 10
@@ -145,8 +147,6 @@ def test_dask_beam_cube():
 
     from africanus.rime.dask import transform_sources
     from africanus.rime.dask import beam_cube_dde
-
-    import dask.array as da
 
     # Dask source transform variables
     dask_lm = da.from_array(lm, chunks=(src_chunks, 2))

--- a/africanus/rime/tests/test_rime.py
+++ b/africanus/rime/tests/test_rime.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import pytest
 
-from africanus.rime.dask import have_requirements
 from africanus.rime.parangles import _discovered_backends
 
 
@@ -275,9 +274,8 @@ def test_predict_vis(corr):
     assert np.allclose(v, model_vis)
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 def test_dask_phase_delay():
-    import dask.array as da
+    da = pytest.importorskip('dask.array')
     from africanus.rime import phase_delay as np_phase_delay
     from africanus.rime.dask import phase_delay as dask_phase_delay
 
@@ -297,7 +295,6 @@ def test_dask_phase_delay():
     assert np.all(np_phase == dask_phase)
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 @pytest.mark.parametrize('backend', [
     'test',
     pytest.param('casa', marks=pytest.mark.skipif(
@@ -308,7 +305,7 @@ def test_dask_phase_delay():
                                 reason="astropy not installed"))])
 @pytest.mark.parametrize('observation', [(2018, 1, 1, 4)])
 def test_dask_parallactic_angles(observation, wsrt_ants, backend):
-    import dask.array as da
+    da = pytest.importorskip('dask.array')
     from africanus.rime import parallactic_angles as np_parangle
     from africanus.rime.dask import parallactic_angles as da_parangle
 
@@ -329,9 +326,8 @@ def test_dask_parallactic_angles(observation, wsrt_ants, backend):
     assert np.all(np_pa == da_pa.compute())
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 def test_dask_feed_rotation():
-    import dask.array as da
+    da = pytest.importorskip('dask.array')
     import numpy as np
     from africanus.rime import feed_rotation as np_feed_rotation
     from africanus.rime.dask import feed_rotation
@@ -346,14 +342,13 @@ def test_dask_feed_rotation():
     assert np.all(np_fr == feed_rotation(dask_parangles, feed_type='circular'))
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 @pytest.mark.parametrize('corr', [
     ((2, 2), "srcij,srcjk,srckl->rcil", "rcij,rcjk,rckl->rcil"),
     ((1,), "srci,srci,srci->rci", "rci,rci,rci->rci"),
     ((2,), "srci,srci,srci->rci", "rci,rci,rci->rci"),
 ])
 def test_dask_predict_vis(corr):
-    import dask.array as da
+    da = pytest.importorskip('dask.array')
     import numpy as np
     from africanus.rime import predict_vis as np_predict_vis
     from africanus.rime.dask import predict_vis

--- a/africanus/rime/tests/test_zernike.py
+++ b/africanus/rime/tests/test_zernike.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from africanus.rime.dask import have_requirements
-
 
 def test_zernike_func_xx_corr(coeff_xx, noll_index_xx, eidos_data_xx):
     """ Tests reconstruction of xx correlation against eidos """
@@ -162,10 +160,7 @@ def test_zernike_func_yy_corr(coeff_yy, noll_index_yy, eidos_data_yy):
 
 def test_zernike_multiple_dims(coeff_xx, noll_index_xx):
     """ Tests that we can call zernike_dde with multiple dimensions """
-    from africanus.rime.dask import zernike_dde
     from africanus.rime import zernike_dde as np_zernike_dde
-
-    import dask.array as da
 
     npix = 17
     nsrc = npix ** 2
@@ -201,13 +196,12 @@ def test_zernike_multiple_dims(coeff_xx, noll_index_xx):
     assert vals.shape == (nsrc, ntime, na, nchan, corr1, corr2)
 
 
-@pytest.mark.skipif(not have_requirements, reason="requirements not installed")
 def test_dask_zernike(coeff_xx, noll_index_xx):
     """ Tests that dask zernike_dde agrees with numpy zernike_dde """
+    da = pytest.importorskip("dask.array")
+
     from africanus.rime.dask import zernike_dde
     from africanus.rime import zernike_dde as np_zernike_dde
-
-    import dask.array as da
 
     npix = 17
     nsrc = npix ** 2

--- a/africanus/stokes/dask.py
+++ b/africanus/stokes/dask.py
@@ -12,59 +12,57 @@ from .stokes_conversion import (stokes_convert_setup, stokes_convert_impl,
                                 stokes_convert as np_stokes_convert,
                                 STOKES_DOCS)
 
-from ..util.docs import on_rtd
-from ..util.requirements import have_packages, MissingPackageException
+from ..util.requirements import requires_optional
 
-_package_requirements = ('dask.array',)
-have_requirements = have_packages(*_package_requirements)
-
-
-if not have_requirements or on_rtd():
-    def stokes_convert(input, input_schema, output_schema):
-        raise MissingPackageException(*_package_requirements)
-else:
+try:
     import dask.array as da
+except ImportError:
+    pass
 
-    # This wraps is a https://en.wikipedia.org/wiki/Noble_lie
-    @wraps(np_stokes_convert)
-    def _wrapper(np_input, mapping=None, in_shape=None,
-                 out_shape=None, dtype_=None):
-        result = stokes_convert_impl(np_input, mapping, in_shape,
-                                     out_shape, dtype_)
 
-        # Introduce extra singleton dimension at the end of our shape
-        return result.reshape(result.shape + (1,) * len(in_shape))
+# This wraps is a https://en.wikipedia.org/wiki/Noble_lie
+@wraps(np_stokes_convert)
+def _wrapper(np_input, mapping=None, in_shape=None,
+             out_shape=None, dtype_=None):
+    result = stokes_convert_impl(np_input, mapping, in_shape,
+                                 out_shape, dtype_)
 
-    def stokes_convert(input, input_schema, output_schema):
-        mapping, in_shape, out_shape, dtype = stokes_convert_setup(
-                                                    input,
-                                                    input_schema,
-                                                    output_schema)
+    # Introduce extra singleton dimension at the end of our shape
+    return result.reshape(result.shape + (1,) * len(in_shape))
 
-        n_free_dims = len(input.shape) - len(in_shape)
-        free_dims = tuple("dim-%d" % i for i in range(n_free_dims))
-        in_corr_dims = tuple("icorr-%d" % i for i in range(len(in_shape)))
-        out_corr_dims = tuple("ocorr-%d" % i for i in range(len(out_shape)))
 
-        # Output dimension are new dimensions
-        new_axes = {d: s for d, s in zip(out_corr_dims, out_shape)}
+@requires_optional("dask.array")
+def stokes_convert(input, input_schema, output_schema):
+    mapping, in_shape, out_shape, dtype = stokes_convert_setup(
+                                                input,
+                                                input_schema,
+                                                output_schema)
 
-        # Note the dummy in_corr_dims introduced at the end of our output,
-        # We do this to prevent a contraction over the input dimensions
-        # (which can be arbitrary) within the wrapper class
-        res = da.core.atop(_wrapper, free_dims + out_corr_dims + in_corr_dims,
-                           input, free_dims + in_corr_dims,
-                           mapping=mapping,
-                           in_shape=in_shape,
-                           out_shape=out_shape,
-                           new_axes=new_axes,
-                           dtype_=dtype,
-                           dtype=dtype)
+    n_free_dims = len(input.shape) - len(in_shape)
+    free_dims = tuple("dim-%d" % i for i in range(n_free_dims))
+    in_corr_dims = tuple("icorr-%d" % i for i in range(len(in_shape)))
+    out_corr_dims = tuple("ocorr-%d" % i for i in range(len(out_shape)))
 
-        # Now contract over the dummy dimensions
-        start = len(free_dims) + len(out_corr_dims)
-        end = start + len(in_corr_dims)
-        return res.sum(axis=list(range(start, end)))
+    # Output dimension are new dimensions
+    new_axes = {d: s for d, s in zip(out_corr_dims, out_shape)}
+
+    # Note the dummy in_corr_dims introduced at the end of our output,
+    # We do this to prevent a contraction over the input dimensions
+    # (which can be arbitrary) within the wrapper class
+    res = da.core.atop(_wrapper, free_dims + out_corr_dims + in_corr_dims,
+                       input, free_dims + in_corr_dims,
+                       mapping=mapping,
+                       in_shape=in_shape,
+                       out_shape=out_shape,
+                       new_axes=new_axes,
+                       dtype_=dtype,
+                       dtype=dtype)
+
+    # Now contract over the dummy dimensions
+    start = len(free_dims) + len(out_corr_dims)
+    end = start + len(in_corr_dims)
+    return res.sum(axis=list(range(start, end)))
+
 
 try:
     stokes_convert.__doc__ = (STOKES_DOCS

--- a/africanus/util/requirements.py
+++ b/africanus/util/requirements.py
@@ -4,41 +4,100 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from functools import wraps
+import importlib
 import logging
+import sys
 
 from .docs import on_rtd
 
+try:
+    import pytest
+except ImportError:
+    pass
+
+
 log = logging.getLogger(__name__)
-
-if on_rtd():
-    # Some dependencies are mock objects within readthedocs
-    # which causes importlib to fail
-    def _package_exists(package):
-        return True
-else:
-    import importlib
-
-    def _package_exists(package):
-        try:
-            importlib.import_module(package)
-            return True
-        except ImportError:
-            return False
-
-_check_packages = set(['dask.array', 'toolz'])
-
-
-def have_packages(*args):
-    unknown_requirements = tuple(p for p in args if p not in _check_packages)
-
-    if len(unknown_requirements) > 0:
-        log.debug("The following requirements "
-                  "are not registered: %s", (unknown_requirements,))
-
-    return all(_package_exists(p) for p in args)
 
 
 class MissingPackageException(Exception):
     def __init__(self, *packages):
         super(MissingPackageException, self).__init__(
             "The following packages must be installed: %s" % (packages,))
+
+
+def requires_optional(*requirements):
+    """
+    Decorator which returns either the original function,
+    or a dummy function which raises a
+    :class:`MissingPackageException` when called,
+    depending on whether the supplied ``requirements``
+    are present.
+
+    If packages are missing and called within a test, the
+    dummy function will call :func:`pytest.skip`.
+
+    Used in the following way:
+
+    .. code-block:: python
+
+        try:
+            from scipy import interpolate
+        except ImportError:
+            pass
+
+        @requires_optional('scipy')
+        def function(*args, **kwargs):
+            return interpolate(...)
+
+
+    Parameters
+    ----------
+    requirements : iterable of string
+        Sequence of packages required by the decorated functions
+
+    Returns
+    -------
+    callable
+        Either the original function if all ``requirements``
+        are available or a dummy function that throws
+        a :class:`MissingPackageException` or skips within
+        a pytest.
+    """
+    have_requirements = True
+    missing_requirements = []
+
+    # Try imports if we're not on RTD
+    if not on_rtd():
+        for package in requirements:
+            try:
+                importlib.import_module(package)
+            except ImportError:
+                missing_requirements.append(package)
+                have_requirements = False
+            else:
+                pass
+
+    def _function_decorator(fn):
+        # Return a bare wrapper if we're on RTD
+        if on_rtd():
+            @wraps(fn)
+            def _wrapper(*arg, **kwargs):
+                pass
+        # We don't have requirements, produce
+        # a failing wrapper
+        elif not have_requirements:
+            @wraps(fn)
+            def _wrapper(*args, **kwargs):
+                if getattr(sys, "_called_from_test", False):
+                    pytest.skip("Missing requirements %s" %
+                                missing_requirements)
+                else:
+                    raise MissingPackageException(*missing_requirements)
+        else:
+            # Return the original function
+            return fn
+
+        return _wrapper
+
+    return _function_decorator

--- a/africanus/util/requirements.py
+++ b/africanus/util/requirements.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
 import importlib
 import logging
 import sys
+
+from decorator import decorate
 
 from .docs import on_rtd
 
@@ -81,19 +82,23 @@ def requires_optional(*requirements):
     def _function_decorator(fn):
         # Return a bare wrapper if we're on RTD
         if on_rtd():
-            @wraps(fn)
-            def _wrapper(*arg, **kwargs):
+            def _wrapper(f, *arg, **kwargs):
+                """ Empty docstring """
                 pass
+
+            return decorate(fn, _wrapper)
         # We don't have requirements, produce
         # a failing wrapper
         elif not have_requirements:
-            @wraps(fn)
-            def _wrapper(*args, **kwargs):
+            def _wrapper(f, *args, **kwargs):
+                """ Empty docstring """
                 if getattr(sys, "_called_from_test", False):
                     pytest.skip("Missing requirements %s" %
                                 missing_requirements)
                 else:
                     raise MissingPackageException(*missing_requirements)
+
+            return decorate(fn, _wrapper)
         else:
             # Return the original function
             return fn

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,14 +18,18 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
+
+import importlib
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 
 try:
     from unittest.mock import MagicMock
 except ImportError:
     from mock import Mock as MagicMock
+
 
 class Mock(MagicMock):
     @classmethod
@@ -35,10 +39,21 @@ class Mock(MagicMock):
             obj.__doc__ = "doc"
             return obj
 
-MOCK_MODULES = ['numba', 'numpy',
-                'scipy', 'scipy.signal', 'scipy.ndimage'
-                ]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+MOCK_MODULES = {}
+_MOCK_MODULES = ['numba', 'numpy']
+
+# Don't mock if we can import it.
+# This allows us to build locally without
+# Mocks interfering with other imports.
+# e.g. np.__version__ getting tested by dask/scipy/astropy
+for m in _MOCK_MODULES:
+    try:
+        importlib.import_module(m)
+    except ImportError:
+        MOCK_MODULES[m] = Mock()
+
+sys.modules.update((k, v) for k, v in MOCK_MODULES.items())
 
 import sphinx_rtd_theme
 import africanus

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,10 +14,31 @@ To install Codex Africanus, run this command in your terminal:
 
     $ pip install codex-africanus
 
-This is the preferred method to install Codex Africanus, as it will always install the most recent stable release.
+This is the preferred method to install Codex Africanus,
+as it will always install the most recent stable release.
 
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
+If you don't have `pip`_ installed, this `Python installation guide`_
+can guide you through the process.
+
+By default, Codex Africanus will install with a minimal set of
+dependencies, numpy and numba.
+
+Further functionality can be enabled by installing extra requirements
+as follows:
+
+.. code-block:: console
+
+    $ pip install codex-africanus[dask]
+    $ pip install codex-africanus[scipy]
+    $ pip install codex-africanus[astropy]
+    $ pip install codex-africanus[python-casacore]
+
+
+To install the complete set of dependencies:
+
+.. code-block:: console
+
+    $ pip install codex-africanus[complete]
 
 .. _pip: https://pip.pypa.io
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/

--- a/docs/util-api.rst
+++ b/docs/util-api.rst
@@ -1,6 +1,16 @@
 Utilities
 ---------
 
+Requirements Handling
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: africanus.util.requirements
+
+.. autosummary::
+    requires_optional
+
+.. autofunction:: africanus.util.requirements.requires_optional
+
 Shapes
 ~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ extras_require = {
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup_requirements = ['pytest-runner', ]
-test_requirements = ['pytest'] + extras_require['complete']
+test_requirements = (['pytest'] +
+                     extras_require['astropy'] +
+                     extras_require['dask'] +
+                     extras_require['scipy'])
 
 setup(
     author="Simon Perkins",

--- a/setup.py
+++ b/setup.py
@@ -7,34 +7,33 @@ import os
 
 from setuptools import setup, find_packages
 
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-
 # requirements
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
 # Basic requirements that contain no C extensions.
 # This is necessary for building on RTD
-requirements = []
+requirements = ['decorator']
 
-if on_rtd:
-    requirements += []
-else:
-    requirements += [
-        'decorator',
-        'numpy >= 1.14.0',
-        'numba >= 0.38.0']
+if not on_rtd:
+    requirements += ['numpy >= 1.14.0', 'numba >= 0.38.0']
+
+extras_require = {
+    'dask': ['dask[array] >= 0.18.0'],
+    'scipy': ['scipy >= 1.0.0'],
+    'astropy': ['astropy >= 2.0.0'],
+    'python-casacore': ['python-casacore >= 2.2.1'],
+}
+
+extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup_requirements = ['pytest-runner', ]
-
-test_requirements = [
-        'pytest',
-        'dask[array] >= 0.17.2']
+test_requirements = ['pytest'] + extras_require['complete']
 
 setup(
     author="Simon Perkins",
@@ -51,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     description="Radio Astronomy Building Blocks",
+    extras_require=extras_require,
     install_requires=requirements,
     license="GNU General Public License v2",
     long_description=readme + '\n\n' + history,

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ if on_rtd:
     requirements += []
 else:
     requirements += [
+        'decorator',
         'numpy >= 1.14.0',
-        'numba >= 0.38.0',
-        'scipy >= 1.0.1']
+        'numba >= 0.38.0']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,10 @@
 """The setup script."""
 
 import os
-
+import sys
 from setuptools import setup, find_packages
+
+PY2 = sys.version_info[0] == 2
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -26,7 +28,7 @@ if not on_rtd:
 extras_require = {
     'dask': ['dask[array] >= 0.18.0'],
     'scipy': ['scipy >= 1.0.0'],
-    'astropy': ['astropy >= 2.0.0'],
+    'astropy': ['astropy >= 2.0.0, < 3.0.0' if PY2 else 'astropy >= 3.0.0'],
     'python-casacore': ['python-casacore >= 2.2.1'],
 }
 


### PR DESCRIPTION
Greatly simplify handling of optional dependencies. The base installation now only requires the following modules.

- decorator
- numpy
- numba

Extra requirement [dask,scipy,astropy,python-casacore] now become available via extras_requires.

Functions depending on these optional extras can be specified via a `optional_requires` decorator in the following manner:

```python
try:
    from scipy import interpolate
except ImportError:
    pass

@requires_optional('scipy')
 def function(*args, **kwargs):
     return interpolate(...)
```



- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
