### PR TITLE
Fix kaiser bessel filter and taper

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
+* Fix Kaiser Bessel filter and taper (:pr:`48`)
 * Stokes/Correlation conversion (:pr:`41`)
 * Fix gridding examples (:pr:`43`)
 * Add simple dask gridder example (:pr:`42`)

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -73,8 +73,7 @@ def convolution_filter(half_support, oversampling_factor,
         Beta shape parameter for
         `Kaiser Bessel <kaiser-bessel-filter_>`_ filters.
     normalise : {True, False}
-        Indicates whether the area under the filter
-        should be normalised to 1.
+        Normalise the filter by the it's volume.
         Defaults to ``True``.
 
     Returns

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -8,7 +8,7 @@ import collections
 
 import numpy as np
 
-from .kaiser_bessel_filter import (kaiser_bessel,
+from .kaiser_bessel_filter import (kaiser_bessel_with_sinc,
                                    estimate_kaiser_bessel_beta)
 
 ConvolutionFilter = collections.namedtuple("ConvolutionFilter",
@@ -99,12 +99,9 @@ def convolution_filter(half_support, oversampling_factor,
             beta = estimate_kaiser_bessel_beta(full_sup)
 
         # Compute Kaiser Bessel and multiply in the sinc
-        filter_taps = kaiser_bessel(taps, full_sup, beta)
-        filter_taps *= np.sinc(taps)
-
-        # Normalise by integrating
-        if normalise:
-            filter_taps /= np.trapz(filter_taps, taps)
+        filter_taps = kaiser_bessel_with_sinc(taps, full_sup,
+                                              oversampling_factor, beta,
+                                              normalise=normalise)
     else:
         raise ValueError("Expected one of {'kaiser-bessel', 'sinc'}")
 

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -72,6 +72,9 @@ def convolution_filter(half_support, oversampling_factor,
     beta : float, optional
         Beta shape parameter for
         `Kaiser Bessel <kaiser-bessel-filter_>`_ filters.
+    normalise : {True, False}
+        Indicates whether the filter should be normalised.
+        Defaults to ``True``.
 
     Returns
     -------
@@ -81,6 +84,8 @@ def convolution_filter(half_support, oversampling_factor,
     full_sup_wo_padding = (half_support * 2 + 1)
     full_sup = full_sup_wo_padding + 2  # + padding
     no_taps = full_sup + (full_sup - 1) * (oversampling_factor - 1)
+
+    normalise = kwargs.pop("normalise", True)
 
     taps = np.arange(no_taps) / oversampling_factor - full_sup // 2
 
@@ -96,9 +101,10 @@ def convolution_filter(half_support, oversampling_factor,
         filter_taps = kaiser_bessel(taps, full_sup, beta)
 
         # Normalise by integrating
-        filter_taps /= np.trapz(filter_taps, taps)
+        if normalise:
+            filter_taps /= np.trapz(filter_taps, taps)
     else:
-        raise ValueError("Expected one of {'kaiser-bessel'}")
+        raise ValueError("Expected one of {'kaiser-bessel', 'sinc'}")
 
     # Expand filter taps to 2D
     filter_taps = np.outer(filter_taps, filter_taps)

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -73,7 +73,8 @@ def convolution_filter(half_support, oversampling_factor,
         Beta shape parameter for
         `Kaiser Bessel <kaiser-bessel-filter_>`_ filters.
     normalise : {True, False}
-        Indicates whether the filter should be normalised.
+        Indicates whether the area under the filter
+        should be normalised to 1.
         Defaults to ``True``.
 
     Returns

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -47,6 +47,10 @@ because they're easier to use when using
 """
 
 
+class AsymmetricKernel(Exception):
+    pass
+
+
 def convolution_filter(half_support, oversampling_factor,
                        filter_type, **kwargs):
     r"""
@@ -98,6 +102,9 @@ def convolution_filter(half_support, oversampling_factor,
 
     # Expand filter taps to 2D
     filter_taps = np.outer(filter_taps, filter_taps)
+
+    if not np.all(filter_taps == filter_taps.T):
+        raise AsymmetricKernel("Kernel is asymmetric")
 
     return ConvolutionFilter(half_support, oversampling_factor,
                              full_sup_wo_padding, full_sup,

--- a/africanus/filters/conv_filters.py
+++ b/africanus/filters/conv_filters.py
@@ -98,7 +98,9 @@ def convolution_filter(half_support, oversampling_factor,
         except KeyError:
             beta = estimate_kaiser_bessel_beta(full_sup)
 
+        # Compute Kaiser Bessel and multiply in the sinc
         filter_taps = kaiser_bessel(taps, full_sup, beta)
+        filter_taps *= np.sinc(taps)
 
         # Normalise by integrating
         if normalise:

--- a/africanus/filters/filter_tapers.py
+++ b/africanus/filters/filter_tapers.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from .kaiser_bessel_filter import (kaiser_bessel,
+from .kaiser_bessel_filter import (kaiser_bessel_with_sinc,
                                    estimate_kaiser_bessel_beta)
 
 
@@ -41,7 +41,8 @@ def taper(filter_type, ny, nx, conv_filter, **kwargs):
         # What would Andre Offringa do?
         # He would compute the numeric solution
         taps = np.arange(cf.no_taps) / cf.oversample - cf.full_sup // 2
-        kb = kaiser_bessel(taps, cf.full_sup, beta)
+        kb = kaiser_bessel_with_sinc(taps, cf.full_sup, cf.oversample,
+                                     beta, normalise=True)
         kbshift = np.fft.fftshift(kb)
 
         width = nx * cf.oversample

--- a/africanus/filters/filter_tapers.py
+++ b/africanus/filters/filter_tapers.py
@@ -52,17 +52,17 @@ def taper(filter_type, ny, nx, conv_filter, **kwargs):
         buf = np.zeros(width, dtype=kb.dtype)
         buf[:kbshift.size // 2] = kbshift[:kbshift.size // 2]
         buf[-kbshift.size // 2:] = kbshift[-kbshift.size // 2:]
-        x = np.fft.fft(buf).real
+        x = np.fft.ifft(buf).real
 
         buf = np.zeros(height, dtype=kb.dtype)
         buf[:kbshift.size // 2] = kbshift[:kbshift.size // 2]
         buf[-kbshift.size // 2:] = kbshift[-kbshift.size // 2:]
-        y = np.fft.fft(buf).real
+        y = np.fft.ifft(buf).real
 
         # First quarter of the taper
         quarter = y[:ny // 2, None] * x[None, :nx // 2]
 
-        # Create the taper of the proper by copying
+        # Create the taper by copying
         # the quarter into the appropriate bits
         taper = np.empty((ny, nx), dtype=kb.dtype)
         taper[:ny // 2, :nx // 2] = quarter[::-1, ::-1]

--- a/africanus/filters/filter_tapers.py
+++ b/africanus/filters/filter_tapers.py
@@ -41,8 +41,7 @@ def taper(filter_type, ny, nx, conv_filter, **kwargs):
         # What would Andre Offringa do?
         # He would compute the numeric solution
         taps = np.arange(cf.no_taps) / cf.oversample - cf.full_sup // 2
-        kb = kaiser_bessel_with_sinc(taps, cf.full_sup, cf.oversample,
-                                     beta, normalise=True)
+        kb = kaiser_bessel_with_sinc(taps, cf.full_sup, cf.oversample, beta)
         kbshift = np.fft.fftshift(kb)
 
         width = nx * cf.oversample
@@ -72,7 +71,7 @@ def taper(filter_type, ny, nx, conv_filter, **kwargs):
         taper[ny // 2:, nx // 2:] = quarter[:, :]
 
         # Normalise by oversampling factor
-        taper /= cf.oversample**2
+        taper *= cf.oversample**2
 
         return taper
     else:

--- a/africanus/filters/filter_tapers.py
+++ b/africanus/filters/filter_tapers.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from .kaiser_bessel_filter import (kaiser_bessel_fourier,
+from .kaiser_bessel_filter import (kaiser_bessel,
                                    estimate_kaiser_bessel_beta)
 
 
@@ -28,23 +28,51 @@ def taper(filter_type, ny, nx, conv_filter, **kwargs):
     :class:`numpy.ndarray`
         Taper of shape :code:`(ny, nx)`
     """
+    cf = conv_filter
+
     if filter_type == "sinc":
-        raise NotImplementedError("Please implement sinc support")
+        return np.ones((ny, nx))
     elif filter_type == "kaiser-bessel":
         try:
             beta = kwargs.pop('beta')
         except KeyError:
-            beta = estimate_kaiser_bessel_beta(conv_filter.full_sup)
+            beta = estimate_kaiser_bessel_beta(cf.full_sup)
 
-        py = np.arange(ny) / ny - 0.5
-        y = kaiser_bessel_fourier(py, conv_filter.full_sup, beta)
-        y *= np.sinc(y / conv_filter.oversample)
+        # What would Andre Offringa do?
+        # He would compute the numeric solution
+        taps = np.arange(cf.no_taps) / cf.oversample - cf.full_sup // 2
+        kb = kaiser_bessel(taps, cf.full_sup, beta)
+        kbshift = np.fft.fftshift(kb)
 
-        px = np.arange(nx) / nx - 0.5
-        x = kaiser_bessel_fourier(px, conv_filter.full_sup, beta)
-        x *= np.sinc(x / conv_filter.oversample)
+        width = nx * cf.oversample
+        height = ny * cf.oversample
 
-        # Produce 2D taper
-        return y[:, None] * x[None, :]
+        # Put the first and last halves of the shifted Kaiser Bessel
+        # at each end of the output buffer, then FFT
+        buf = np.zeros(width, dtype=kb.dtype)
+        buf[:kbshift.size // 2] = kbshift[:kbshift.size // 2]
+        buf[-kbshift.size // 2:] = kbshift[-kbshift.size // 2:]
+        x = np.fft.fft(buf).real
+
+        buf = np.zeros(height, dtype=kb.dtype)
+        buf[:kbshift.size // 2] = kbshift[:kbshift.size // 2]
+        buf[-kbshift.size // 2:] = kbshift[-kbshift.size // 2:]
+        y = np.fft.fft(buf).real
+
+        # First quarter of the taper
+        quarter = y[:ny // 2, None] * x[None, :nx // 2]
+
+        # Create the taper of the proper by copying
+        # the quarter into the appropriate bits
+        taper = np.empty((ny, nx), dtype=kb.dtype)
+        taper[:ny // 2, :nx // 2] = quarter[::-1, ::-1]
+        taper[ny // 2:, :nx // 2] = quarter[:, ::-1]
+        taper[:ny // 2, nx // 2:] = quarter[::-1, :]
+        taper[ny // 2:, nx // 2:] = quarter[:, :]
+
+        # Normalise by oversampling factor
+        taper /= cf.oversample**2
+
+        return taper
     else:
         raise ValueError("Invalid filter_type '%s'" % filter_type)

--- a/africanus/filters/kaiser_bessel_filter.py
+++ b/africanus/filters/kaiser_bessel_filter.py
@@ -15,7 +15,11 @@ def estimate_kaiser_bessel_beta(full_support):
 
     .. math::
 
-        \beta = 1.2 \pi \sqrt{0.25 \text{ W }^2 - 1.0 }
+        \beta = 2.34 \times W
+
+    Derived from `Nonuniform fast Fourier transforms
+    using min-max interpolation
+    <https://ieeexplore.ieee.org/document/1166689/>`_.
 
     Parameters
     ----------
@@ -25,18 +29,10 @@ def estimate_kaiser_bessel_beta(full_support):
     Returns
     -------
     float
-        kaiser Bessel beta shape parameter
+        Kaiser Bessel beta shape parameter
     """
 
-    # NOTE(bmerry)
-    # Puts the first null of the taper function
-    # at the edge of the image
-    beta = np.pi * np.sqrt(0.25 * full_support**2 - 1.0)
-    # Move the null outside the image,
-    # to avoid numerical instabilities.
-    # This will cause a small amount of aliasing at the edges,
-    # which ideally should be handled by clipping the image.
-    return beta * 1.2
+    return 2.34*full_support
 
 
 def kaiser_bessel(taps, full_support, beta):
@@ -68,7 +64,7 @@ def kaiser_bessel(taps, full_support, beta):
     return np.i0(beta * np.sqrt(param)) / np.i0(beta)
 
 
-def kaiser_bessel_fourier(positions, full_support, beta):
+def kaiser_bessel_fourier(taps, npix, beta):
     r"""
     Computes the Fourier Transform of a 1D Kaiser Bessel filter.
 
@@ -76,16 +72,17 @@ def kaiser_bessel_fourier(positions, full_support, beta):
     ----------
     positions : :class:`numpy.ndarray`
         Filter positions
-    full_support : int
-        Full support of the associated convolution filter.
+    npix : int
+        Number of pixels.
     beta : float
         Kaiser bessel shape parameter
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of shape :code:`(positions,)
+        Array of shape :code:`(taps,)
     """
-    alpha = beta / np.pi
-    inner = np.lib.scimath.sqrt((full_support * positions)**2 - alpha * alpha)
-    return full_support * np.sinc(inner).real / np.i0(beta)
+    term = (np.pi*npix*taps)**2 - beta**2
+    val = np.lib.scimath.sqrt(term).real
+    val = np.sqrt(term)
+    return np.sin(val)/val

--- a/africanus/filters/kaiser_bessel_filter.py
+++ b/africanus/filters/kaiser_bessel_filter.py
@@ -56,7 +56,7 @@ def kaiser_bessel(u, W, beta):
     Returns
     -------
     :class:`numpy.ndarray`
-        Kaiser Bessel filter of shape :code:`(u,)`
+        Kaiser Bessel filter with the same shape as `u`
     """
 
     # Sanity check
@@ -90,7 +90,7 @@ def kaiser_bessel_with_sinc(u, W, oversample, beta, normalise=True):
     Returns
     -------
     :class:`numpy.ndarray`
-        The filter
+        Filter with the same shape as `u`
     """
     kb = kaiser_bessel(u, W, beta)
     kb *= oversample
@@ -124,7 +124,8 @@ def kaiser_bessel_fourier(x, W, beta):
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of shape :code:`(x,)`
+        Fourier Transform of the Kaiser Bessel,
+        with the same shape as `x`.
     """
     term = (np.pi*W*x)**2 - beta**2
     val = np.lib.scimath.sqrt(term).real

--- a/africanus/filters/plot_filter.py
+++ b/africanus/filters/plot_filter.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import argparse
 import logging
 
@@ -29,11 +36,7 @@ def create_parser():
 
 
 @requires_optional('matplotlib.pyplot', 'mpl_toolkits.mplot3d')
-def main():
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
-
-    args = create_parser().parse_args()
-
+def _plot_filter(args):
     logging.info("Creating %s filter with half support of %d "
                  "and %d oversampling" %
                  (args.filter, args.half_support, args.oversample))
@@ -72,3 +75,8 @@ def main():
     fig.colorbar(surf, shrink=0.5, aspect=5)
 
     plt.show()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    _plot_filter(create_parser().parse_args())

--- a/africanus/filters/plot_filter.py
+++ b/africanus/filters/plot_filter.py
@@ -29,8 +29,12 @@ def create_parser():
                    default='kaiser-bessel')
     p.add_argument("-hs", "--half-support", default=3, type=int)
     p.add_argument("-os", "--oversample", default=63, type=int)
-    p.add_argument("-n", "--normalise", action="store_true")
-    p.add_argument("-k", "--kwargs", default="", type=parse_python_assigns)
+    p.add_argument("-nn", "--no-normalise", action="store_false",
+                   help="Don't normalise area under the filter to 1")
+    p.add_argument("-k", "--kwargs", default="", type=parse_python_assigns,
+                   help="Extra keywords arguments used to create the filter. "
+                        "For example 'beta=2.3' to specify a beta shape "
+                        "parameter for the Kaiser Bessel")
 
     return p
 
@@ -47,7 +51,7 @@ def _plot_filter(args):
     conv_filter = convolution_filter(args.half_support,
                                      args.oversample,
                                      args.filter,
-                                     normalise=args.normalise,
+                                     normalise=not args.no_normalise,
                                      **args.kwargs)
 
     data = np.abs(conv_filter.filter_taps)

--- a/africanus/filters/plot_filter.py
+++ b/africanus/filters/plot_filter.py
@@ -1,0 +1,74 @@
+import argparse
+import logging
+
+from ..filters import convolution_filter
+from ..util.cmdline import parse_python_assigns
+from ..util.requirements import requires_optional
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib import cm
+    from matplotlib.ticker import LinearLocator, FormatStrFormatter
+    from mpl_toolkits.mplot3d import Axes3D  # noqa
+except ImportError:
+    pass
+
+
+def create_parser():
+    p = argparse.ArgumentParser()
+    p.add_argument("filter", choices=['kaiser-bessel', 'sinc'],
+                   default='kaiser-bessel')
+    p.add_argument("-hs", "--half-support", default=3, type=int)
+    p.add_argument("-os", "--oversample", default=63, type=int)
+    p.add_argument("-n", "--normalise", action="store_true")
+    p.add_argument("-k", "--kwargs", default="", type=parse_python_assigns)
+
+    return p
+
+
+@requires_optional('matplotlib.pyplot', 'mpl_toolkits.mplot3d')
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    args = create_parser().parse_args()
+
+    logging.info("Creating %s filter with half support of %d "
+                 "and %d oversampling" %
+                 (args.filter, args.half_support, args.oversample))
+
+    if len(args.kwargs) > 0:
+        logging.info("Extra keywords %s" % args.kwargs)
+
+    conv_filter = convolution_filter(args.half_support,
+                                     args.oversample,
+                                     args.filter,
+                                     normalise=args.normalise,
+                                     **args.kwargs)
+
+    data = np.abs(conv_filter.filter_taps)
+
+    X, Y = np.mgrid[-1:1:1j*data.shape[0], -1:1:1j*data.shape[1]]
+
+    fig = plt.figure()
+    ax = fig.gca(projection='3d')
+
+    # Plot the surface.
+    surf = ax.plot_surface(X, Y, data, cmap=cm.coolwarm,
+                           linewidth=0, antialiased=False)
+
+    zmax = data.max()
+
+    ax.plot([0, 0], [0, 0], zs=[0, 1.2*zmax], color='black')
+    ax.plot([0, 0], [-1, 1], zs=[zmax, zmax], color='black')
+    ax.plot([-1, 1], [0, 0], zs=[zmax, zmax], color='black')
+
+    # Customize the z axis.
+    ax.zaxis.set_major_locator(LinearLocator(10))
+    ax.zaxis.set_major_formatter(FormatStrFormatter('%.02f'))
+
+    # Add a color bar which maps values to colors.
+    fig.colorbar(surf, shrink=0.5, aspect=5)
+
+    plt.show()

--- a/africanus/filters/plot_taper.py
+++ b/africanus/filters/plot_taper.py
@@ -49,13 +49,6 @@ def _plot_taper(data, ny, nx, beta=None):
     hx = nx // 2
     X, Y = np.mgrid[-hy:hy:1j*data.shape[0], -hx:hx:1j*data.shape[1]]
 
-    plt.figure()
-    plt.imshow(data)
-    plt.colorbar()
-    plt.show()
-
-    return
-
     fig = plt.figure()
     ax = fig.gca(projection='3d')
 
@@ -63,11 +56,17 @@ def _plot_taper(data, ny, nx, beta=None):
     surf = ax.plot_surface(X, Y, data, cmap=cm.coolwarm,
                            linewidth=0, antialiased=False)
 
+    xmin = -data.shape[0] // 2
+    xmax = data.shape[0] // 2
+
+    ymin = -data.shape[1] // 2
+    ymax = data.shape[1] // 2
+
     zmax = data.max()
 
     ax.plot([0, 0], [0, 0], zs=[0, 1.2*zmax], color='black')
-    ax.plot([0, 0], [-1, 1], zs=[zmax, zmax], color='black')
-    ax.plot([-1, 1], [0, 0], zs=[zmax, zmax], color='black')
+    ax.plot([0, 0], [ymin, ymax], zs=[zmax, zmax], color='black')
+    ax.plot([xmin, xmax], [0, 0], zs=[zmax, zmax], color='black')
 
     # Customize the z axis.
     ax.zaxis.set_major_locator(LinearLocator(10))

--- a/africanus/gridding/wstack/wstacking.py
+++ b/africanus/gridding/wstack/wstacking.py
@@ -79,7 +79,7 @@ def w_stacking_bins(w_min, w_max, w_layers):
 
 
 def _w_stacking_centroids(w_bins):
-    return (w_bins[1:] + w_bins[:1]) / 2.0
+    return 0.5*(w_bins[:-1] + w_bins[1:])
 
 
 WSTACK_DOCS = r"""

--- a/africanus/gridding/wstack/wstacking.py
+++ b/africanus/gridding/wstack/wstacking.py
@@ -129,12 +129,13 @@ def numba_grid(vis, uvw, flags, weights, ref_wave,
     if np.any(bin_indices >= len(grids)):
         raise ValueError("bin_index >= len(grids)")
 
-    w_values = w_stacking_centroids(w_bins)
-    assert len(grids) == w_values.shape[0]
-
-    for i, (w_value, grid) in enumerate(zip(w_values, grids)):
+    for i, grid in enumerate(grids):
         # The row mask for this layer
         mask = bin_indices == i
+
+        # Nothing to grid
+        if np.sum(mask) == 0:
+            continue
 
         simple_numba_grid(vis[mask, ...],
                           uvw[mask, ...],
@@ -240,24 +241,21 @@ def numba_degrid(grids, uvw, weights, ref_wave, convolution_filter,
     if np.any(bin_indices >= len(grids)):
         raise ValueError("bin_index >= len(grids)")
 
-    w_values = w_stacking_centroids(w_bins)
-    assert len(grids) == w_values.shape[0]
-
-    for i, (w_value, grid) in enumerate(zip(w_values, grids)):
+    for i, grid in enumerate(grids):
         # The row mask for this layer
         mask = bin_indices == i
+        rows = np.sum(mask)
 
-        # Set w coordinate to that of the layer
-        discretised_uvw = uvw[mask, ...]
-        discretised_uvw[:, 2] = w_value
+        # Nothing to degrid
+        if rows == 0:
+            continue
 
-        row, _ = discretised_uvw.shape
         _, chan, corr = vis.shape
 
-        res_vis = np.zeros((row, chan, corr), dtype=grid.dtype)
+        res_vis = np.zeros((rows, chan, corr), dtype=grid.dtype)
 
         simple_numba_degrid(grid,
-                            discretised_uvw,
+                            uvw[mask, ...],
                             weights[mask, ...],
                             ref_wave,
                             convolution_filter,

--- a/africanus/util/cmdline.py
+++ b/africanus/util/cmdline.py
@@ -1,0 +1,123 @@
+import ast
+
+import __builtin__
+
+# builtin function whitelist
+_BUILTIN_WHITELIST = frozenset(['slice'])
+_missing = _BUILTIN_WHITELIST.difference(dir(__builtin__))
+if len(_missing) > 0:
+    raise ValueError("'%s' are not valid builtin functions.'" % list(_missing))
+
+
+def parse_python_assigns(assign_str):
+    """
+    Parses a string, containing assign statements
+    into a dictionary.
+
+    .. code-block:: python
+
+        data = parse_python_assigns("beta=5.6; l=[2,3], s='hello, world'")
+
+        assert data == {
+            'beta': 5.6,
+            'l': [2, 3],
+            's': 'hello, world'
+        }
+
+    Parameters
+    ----------
+    assign_str: str
+        Assignment string. Should only contain assignment statements
+        assigning python literals or builtin function calls, to variable names.
+        Multiple assignment statements should be separated by semi-colons.
+
+    Returns
+    -------
+    dict
+        Dictionary { name: value } containing
+        assignment results.
+    """
+
+    if not assign_str:
+        return {}
+
+    def _eval_value(stmt_value):
+        # If the statement value is a call to a builtin, try evaluate it
+        if isinstance(stmt_value, ast.Call):
+            func_name = stmt_value.func.id
+
+            if func_name not in _BUILTIN_WHITELIST:
+                raise ValueError("Function '%s' in '%s' is not builtin. "
+                                 "Available builtins: '%s'" %
+                                 (func_name, assign_str,
+                                  list(_BUILTIN_WHITELIST)))
+
+            # Recursively pass arguments through this same function
+            if stmt_value.args is not None:
+                args = tuple(_eval_value(a) for a in stmt_value.args)
+            else:
+                args = ()
+
+            # Recursively pass keyword arguments through this same function
+            if stmt_value.keywords is not None:
+                kwargs = {kw.arg: _eval_value(kw.value) for kw
+                          in stmt_value.keywords}
+            else:
+                kwargs = {}
+
+            return getattr(__builtin__, func_name)(*args, **kwargs)
+        # Try a literal eval
+        else:
+            return ast.literal_eval(stmt_value)
+
+    # Variable dictionary
+    variables = {}
+
+    # Parse the assignment string
+    stmts = ast.parse(assign_str, mode='single').body
+
+    for i, stmt in enumerate(stmts):
+        if not isinstance(stmt, ast.Assign):
+            raise ValueError("Statement %d in '%s' is not a "
+                             "variable assignment." % (i, assign_str))
+
+        # Evaluate assignment lhs
+        values = _eval_value(stmt.value)
+
+        # "a = b = c" => targets 'a' and 'b' with 'c' as result
+        for target in stmt.targets:
+            # a = 2
+            if isinstance(target, ast.Name):
+                variables[target.id] = values
+
+            # Tuple/List unpacking case
+            # (a, b) = 2
+            elif isinstance(target, (ast.Tuple, ast.List)):
+                # Require all tuple/list elements to be variable names,
+                # although anything else is probably a syntax error
+                if not all(isinstance(e, ast.Name) for e in target.elts):
+                    raise ValueError("Tuple unpacking in assignment %d "
+                                     "in expression '%s' failed as not all "
+                                     "tuple contents are variable names.")
+
+                # Promote for zip and length checking
+                if not isinstance(values, (tuple, list)):
+                    elements = (values,)
+                else:
+                    elements = values
+
+                if not len(target.elts) == len(elements):
+                    raise ValueError("Unpacking '%s' into a tuple/list in "
+                                     "assignment %d of expression '%s' "
+                                     "failed. The number of tuple elements "
+                                     "did not match the number of values."
+                                     % (values, i, assign_str))
+
+                # Unpack
+                for variable, value in zip(target.elts, elements):
+                    variables[variable.id] = value
+            else:
+                raise TypeError("'%s' types are not supported"
+                                "as assignment targets." % type(target))
+
+    return variables

--- a/africanus/util/cmdline.py
+++ b/africanus/util/cmdline.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import ast
 
 import __builtin__

--- a/docs/cmdline-utils.rst
+++ b/docs/cmdline-utils.rst
@@ -1,0 +1,14 @@
+Command Line Utilities
+----------------------
+
+The following command line utilities are installed.
+Run each utility's help for further information.
+
+.. code-block:: console
+
+    $ utility --help
+
+plot-filter
+~~~~~~~~~~~
+
+Plots convolution filters.

--- a/docs/cmdline-utils.rst
+++ b/docs/cmdline-utils.rst
@@ -12,3 +12,8 @@ plot-filter
 ~~~~~~~~~~~
 
 Plots convolution filters.
+
+plot-taper
+~~~~~~~~~~
+
+Plots tapers associated with convolution filters.

--- a/docs/conv-filter-api.rst
+++ b/docs/conv-filter-api.rst
@@ -5,21 +5,6 @@ Convolution Filters
 
 Convolution filters suitable for use in gridding and degridding.
 
-.. _kaiser-bessel-filter:
-
-Kaiser Bessel
-~~~~~~~~~~~~~
-
-The `Kaiser Bessel
-<https://www.dsprelated.com/freebooks/sasp/Kaiser_Window.html>`_
-function.
-
-
-Sinc
-~~~~
-
-The `Sinc <https://en.wikipedia.org/wiki/Sinc_function>`_ function.
-
 API
 ~~~
 
@@ -31,4 +16,30 @@ API
 
 .. autofunction:: convolution_filter
 .. autodata:: ConvolutionFilter
+
+
+.. _kaiser-bessel-filter:
+
+Kaiser Bessel
+~~~~~~~~~~~~~
+
+The `Kaiser Bessel
+<https://www.dsprelated.com/freebooks/sasp/Kaiser_Window.html>`_
+function.
+
+.. currentmodule:: africanus.filters.kaiser_bessel_filter
+
+.. autosummary::
+    kaiser_bessel
+    estimate_kaiser_bessel_beta
+
+
+.. autofunction:: kaiser_bessel
+.. autofunction:: estimate_kaiser_bessel_beta
+
+
+Sinc
+~~~~
+
+The `Sinc <https://en.wikipedia.org/wiki/Sinc_function>`_ function.
 

--- a/docs/conv-filter-api.rst
+++ b/docs/conv-filter-api.rst
@@ -31,10 +31,14 @@ function.
 
 .. autosummary::
     kaiser_bessel
+    kaiser_bessel_with_sinc
+    kaiser_bessel_fourier
     estimate_kaiser_bessel_beta
 
 
 .. autofunction:: kaiser_bessel
+.. autofunction:: kaiser_bessel_with_sinc
+.. autofunction:: kaiser_bessel_fourier
 .. autofunction:: estimate_kaiser_bessel_beta
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to Codex Africanus's documentation!
    readme
    installation
    usage
+   cmdline-utils
    api
    contributing
    authors

--- a/docs/util-api.rst
+++ b/docs/util-api.rst
@@ -1,6 +1,17 @@
 Utilities
 ---------
 
+Command Line
+~~~~~~~~~~~~
+
+.. currentmodule:: africanus.util.cmdline
+
+.. autosummary::
+    parse_python_assigns
+
+.. autofunction:: africanus.util.cmdline.parse_python_assigns
+
+
 Requirements Handling
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/gridding/simple/toygrid.py
+++ b/examples/gridding/simple/toygrid.py
@@ -31,7 +31,7 @@ def create_parser():
 args = create_parser().parse_args()
 
 # Convolution Filter
-conv_filter = convolution_filter(3, 63, "kaiser-bessel")
+conv_filter = convolution_filter(3, 7, "kaiser-bessel")
 
 taper = filter_taper("kaiser-bessel", args.npix, args.npix, conv_filter)
 

--- a/examples/gridding/wstacking/toygrid.py
+++ b/examples/gridding/wstacking/toygrid.py
@@ -29,7 +29,6 @@ import logging
 import numpy as np
 import pyrap.tables as pt
 
-from africanus.coordinates import (radec_to_lmn)
 from africanus.gridding.wstack import (grid,
                                        degrid,
                                        w_stacking_layers,
@@ -38,7 +37,6 @@ from africanus.gridding.wstack import (grid,
 from africanus.gridding.util import estimate_cell_size
 from africanus.constants import c as lightspeed
 from africanus.filters import (convolution_filter, taper as filter_taper)
-
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -65,7 +63,7 @@ with pt.table("::".join((args.ms, "FIELD"))) as FIELD:
     phase_centre = FIELD.getcol("PHASE_DIR")[0][0]
 
 # Convolution Filter
-conv_filter = convolution_filter(3, 63, "kaiser-bessel")
+conv_filter = convolution_filter(3, 7, "kaiser-bessel")
 taper = filter_taper("kaiser-bessel", args.npix, args.npix, conv_filter)
 
 # Determine UVW Coordinate extents
@@ -95,32 +93,31 @@ else:
 
 cell_size_rad = np.deg2rad(cell_size / (60*60))
 
-
 if args.n_wlayers is None:
-    w_layers = w_stacking_layers(wmin, wmax, lmn[:, 0], lmn[:, 1])
+    l = np.mgrid[-(args.npix//2):args.npix//2:1j*args.npix] * cell_size_rad
+    m = np.mgrid[-(args.npix//2):args.npix//2:1j*args.npix] * cell_size_rad
+    w_layers = w_stacking_layers(wmin, wmax, l, m)
 else:
     w_layers = args.n_wlayers
 
 w_bins = w_stacking_bins(wmin, wmax, w_layers)
 w_centroids = w_stacking_centroids(w_bins)
+logging.info("W extents [%.3f, %.3f]" % (wmin, wmax))
+logging.info("W bins %s" % (w_bins,))
 logging.info("%d W layers at %s", w_layers, w_centroids)
 logging.info("Chose a cell_size of %.3f arcseconds" % cell_size)
 
 
 def phase_screen(npix):
-    y = npix - np.arange(npix) + npix // 2
-    x = npix - np.arange(npix) + npix // 2
-    y[y >= npix] -= npix
-    x[x >= npix] -= npix
-    m = ((y - npix // 2) * cell_size_rad)
-    l = ((x - npix // 2) * cell_size_rad)
-
+    l = np.mgrid[-(npix//2):npix//2:1j*npix] * cell_size_rad
+    m = np.mgrid[-(npix//2):npix//2:1j*npix] * cell_size_rad
     square = l[None, :]**2 + m[:, None]**2
     valid = square < 1.0
 
-    n = np.empty_like(square)
-    n[valid] = np.sqrt(1.0 - square[valid]) - 1
-    n[~valid] = 0
+    n = np.empty((npix, npix), dtype=square.dtype)
+    n[valid] = np.sqrt(1.0 - square[valid]) - 1.0
+    n[~valid] = 0.0
+
     return n
 
 
@@ -186,7 +183,7 @@ for w, (dirty, psf, w_centroid) in enumerate(zip(dirties, psfs, w_centroids)):
 
     # FFT each correlation
     fft = np.empty_like(dirty)
-    grid_factor = np.exp(2*np.pi*1j*w_centroid*(grid_n))
+    grid_factor = np.exp(2*np.pi*1j*w_centroid*grid_n)
 
     for c in range(ncorr):
         fft[:, :, c] = np.fft.ifftshift(dirty[:, :, c])
@@ -205,7 +202,7 @@ for w, (dirty, psf, w_centroid) in enumerate(zip(dirties, psfs, w_centroids)):
 
     # FFT the PSF
     psf_fft = np.fft.fftshift(np.fft.ifft2(np.fft.ifftshift(psf[:, :, 0])))
-    psf_fft *= np.exp(2*np.pi*1j*w_centroid*(psf_n))
+    psf_fft *= np.exp(2*np.pi*1j*w_centroid*psf_n)
     psf_sum += psf_fft
 
 grid_final_factor = (1 + grid_n)  # / (wmax - wmin)
@@ -259,7 +256,7 @@ for w, w_centroid in enumerate(w_centroids):
     ncorr = dirty.shape[2]
 
     vis_grid = np.empty(dirty.shape, np.complex64)
-    grid_factor = np.exp(2*np.pi*1j*w_centroid*(grid_n))
+    grid_factor = np.exp(-2*np.pi*1j*w_centroid*(grid_n))
 
     for c in range(ncorr):
         vis_grid[:, :, c] = np.fft.fftshift(dirty[:, :, c])

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     description="Radio Astronomy Building Blocks",
+    entry_points={
+        'console_scripts': ['plot-filter=africanus.filters.plot_filter:main'],
+    },
     extras_require=extras_require,
     install_requires=requirements,
     license="GNU General Public License v2",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
     ],
     description="Radio Astronomy Building Blocks",
     entry_points={
-        'console_scripts': ['plot-filter=africanus.filters.plot_filter:main'],
+        'console_scripts': [
+            'plot-filter=africanus.filters.plot_filter:main',
+            'plot-taper=africanus.filters.plot_taper:main'],
     },
     extras_require=extras_require,
     install_requires=requirements,


### PR DESCRIPTION
- Fix Kaiser Bessel filter by multiplying through by the `sinc` function.
- Numerically compute the taper of the Kaiser Bessel.
- Add plot-filter and plot-taper command-line utilities.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
