### PR TITLE
Fix missing index in dask gridding function

### DIFF
--- a/africanus/gridding/simple/dask.py
+++ b/africanus/gridding/simple/dask.py
@@ -35,7 +35,7 @@ def grid(vis, uvw, flags, weights, ref_wave,
     """ Documentation below """
 
     # Creation correlation dimension strings for each correlation
-    corrs = tuple('corr-%d' for i in range(len(vis.shape[2:])))
+    corrs = tuple('corr-%d' % i for i in range(len(vis.shape[2:])))
 
     # Get grids, stacked by row
     grids = da.core.atop(_grid_fn, ("row", "ny", "nx") + corrs,


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
