### PR TITLE
Fix dask degridding correlations dimensions

### DIFF
--- a/africanus/gridding/simple/dask.py
+++ b/africanus/gridding/simple/dask.py
@@ -66,7 +66,7 @@ def degrid(grid, uvw, weights, ref_wave, convolution_filter, cell_size):
     assert weights.shape[1] == ref_wave.shape[0]
 
     # Creation correlation dimension strings for each correlation
-    corrs = tuple('corr-%d' for i in range(len(grid.shape[2:])))
+    corrs = tuple('corr-%d' % i for i in range(len(grid.shape[2:])))
 
     return da.core.atop(np_degrid_fn, ("row", "chan") + corrs,
                         grid, ("ny", "nx") + corrs,


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
