### PR TITLE
Return environment in jinja2 creation function

### DIFF
--- a/africanus/util/jinja2.py
+++ b/africanus/util/jinja2.py
@@ -105,7 +105,7 @@ class FakeEnvironment(object):
         raise NotImplementedError()
 
 
-def _create_jinja2_env():
+def _jinja2_env_factory():
     try:
         from jinja2 import Environment, PackageLoader, select_autoescape
     except ImportError:
@@ -124,5 +124,7 @@ def _create_jinja2_env():
     env.globals['register_assign_cycles'] = register_assign_cycles
     env.globals['throw'] = throw_helper
 
+    return env
 
-jinja_env = _create_jinja2_env()
+
+jinja_env = _jinja2_env_factory()


### PR DESCRIPTION
This was left out

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
