### PR TITLE
Test case improvements

### DIFF
--- a/africanus/rime/cuda/feeds.py
+++ b/africanus/rime/cuda/feeds.py
@@ -40,8 +40,12 @@ def _generate_kernel(parallactic_angles, feed_type):
     dtype = parallactic_angles.dtype
 
     # Block sizes
-    blockdimx = 1024
-    block = (blockdimx, 1, 1)
+    if dtype == np.float32:
+        block = (1024, 1, 1)
+    elif dtype == np.float64:
+        block = (512, 1, 1)
+    else:
+        raise TypeError("Unhandled type %s" % dtype)
 
     # Create template
     render = jinja_env.get_template(_TEMPLATE_PATH).render

--- a/africanus/rime/cuda/tests/test_feed_rotation.py
+++ b/africanus/rime/cuda/tests/test_feed_rotation.py
@@ -22,15 +22,4 @@ def test_cuda_feed_rotation(feed_type, shape, dtype):
     cp_feed_rot = cp_feed_rotation(cp.asarray(pa), feed_type=feed_type)
     np_feed_rot = np_feed_rotation(pa, feed_type=feed_type)
 
-    cp_feed_rot = cp.asnumpy(cp_feed_rot)
-
-    if not np.allclose(cp_feed_rot, np_feed_rot):
-        d = np.invert(np.isclose(cp_feed_rot, np_feed_rot))
-
-        for idx in zip(*np.nonzero(d)):
-            print(idx, cp_feed_rot[idx], np_feed_rot[idx])
-
-        # for idx in np.asarray(np.nonzero(d)).T:
-        #     print(idx, cp_feed_rot[idx], np_feed_rot[idx])
-
-    assert np.allclose(cp_feed_rot, np_feed_rot)
+    np.testing.assert_array_almost_equal(cp.asnumpy(cp_feed_rot), np_feed_rot)

--- a/africanus/rime/cuda/tests/test_phase_delay.py
+++ b/africanus/rime/cuda/tests/test_phase_delay.py
@@ -11,8 +11,11 @@ from africanus.rime import phase_delay as np_phase_delay
 from africanus.rime.cuda.phase import phase_delay as cp_phase_delay
 
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_cuda_phase_delay(dtype):
+@pytest.mark.parametrize("dtype, decimal", [
+    (np.float32, 5),
+    (np.float64, 6)
+])
+def test_cuda_phase_delay(dtype, decimal):
     cp = pytest.importorskip('cupy')
 
     lm = 0.01*np.random.random((10, 2)).astype(dtype)
@@ -24,4 +27,5 @@ def test_cuda_phase_delay(dtype):
                                    cp.asarray(freq))
     np_cplx_phase = np_phase_delay(lm, uvw, freq)
 
-    assert np.allclose(cp.asnumpy(cp_cplx_phase), np_cplx_phase)
+    np.testing.assert_array_almost_equal(cp.asnumpy(cp_cplx_phase),
+                                         np_cplx_phase, decimal=decimal)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
