### PR TITLE
Experiments with a phase_delay in google jax

### DIFF
--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -3,5 +3,5 @@ RUN docker-apt-install python-pip python-casacore
 RUN pip install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip install .[astropy,dask,jax,python-casacore,scipy,testing]
+RUN pip install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -3,5 +3,5 @@ RUN docker-apt-install python-pip python-casacore
 RUN pip install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip install .[astropy,dask,python-casacore,scipy,testing]
+RUN pip install .[astropy,dask,jax,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -6,5 +6,5 @@ RUN docker-apt-install python3-pip # python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[astropy,dask,scipy,testing]
+RUN pip3 install .[astropy,dask,jax,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -6,5 +6,5 @@ RUN docker-apt-install python3-pip # python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[astropy,dask,jax,scipy,testing]
+RUN pip3 install .[astropy,dask,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -6,5 +6,5 @@ RUN docker-apt-install python3-pip # python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[astropy,dask,scipy,testing]
+RUN pip3 install .[astropy,dask,jax,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -6,5 +6,5 @@ RUN docker-apt-install python3-pip # python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[astropy,dask,jax,scipy,testing]
+RUN pip3 install .[astropy,dask,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/africanus/rime/jax/README.rst
+++ b/africanus/rime/jax/README.rst
@@ -1,0 +1,7 @@
+Experimental RIME with Google JAX
+=================================
+
+Google `jax <https://github.com/google/jax_>`_ supports
+
+- jit compilation of numpy code to both CPU and GPU targets
+- autodiff gradients, jacobians and hessians

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as onp
+
 try:
     import jax.numpy as np
 except ImportError as e:
@@ -28,7 +30,8 @@ def phase_delay(lm, uvw, frequency):
 
     n = np.sqrt(1.0 - l**2 - m**2) - 1.0
 
-    real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
+    real_phase = l * u + m * v + n * w
+    real_phase = lm.dtype.type(minus_two_pi_over_c) * real_phase
     real_phase *= frequency[None, None, :]
 
     return np.exp(1j*real_phase)

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    import jax.numpy as np
+except ImportError as e:
+    opt_import_error = e
+else:
+    opt_import_error = None
+
+from africanus.constants import minus_two_pi_over_c
+from africanus.util.requirements import requires_optional
+
+
+@requires_optional('jax', opt_import_error)
+def phase_delay(lm, uvw, frequency):
+    out_dtype = np.result_type(lm, uvw, frequency, np.complex64)
+
+    l = lm[:, 0, None, None]
+    m = lm[:, 1, None, None]
+
+    u = uvw[None, :, 0, None]
+    v = uvw[None, :, 1, None]
+    w = uvw[None, :, 2, None]
+
+    n = np.sqrt(1.0 - l**2 - m**2) - 1.0
+
+    real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
+    real_phase *= frequency[None, None, :]
+
+    return np.exp(1j*real_phase)

--- a/africanus/rime/jax/tests/test_jax_phase_delay.py
+++ b/africanus/rime/jax/tests/test_jax_phase_delay.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as onp
+import pytest
+
+from africanus.rime.phase import phase_delay as np_phase_delay
+from africanus.rime.jax.phase import phase_delay
+
+
+def test_jax_phase_delay():
+    jax = pytest.importorskip('jax')
+    np = pytest.importorskip('jax.numpy')
+
+    uvw = onp.random.random(size=(100, 3))
+    lm = onp.random.random(size=(10, 2))*0.001
+    frequency = np.linspace(.856e9, .856e9*2, 64, endpoint=True)
+
+    # Compute complex phase
+    complex_phase = jax.jit(phase_delay)(lm, uvw, frequency)
+    np_complex_phase = np_phase_delay(lm, uvw, frequency)
+
+    onp.testing.assert_array_almost_equal(complex_phase, np_complex_phase)

--- a/africanus/rime/jax/tests/test_jax_phase_delay.py
+++ b/africanus/rime/jax/tests/test_jax_phase_delay.py
@@ -11,6 +11,7 @@ from africanus.rime.phase import phase_delay as np_phase_delay
 from africanus.rime.jax.phase import phase_delay
 
 
+@pytest.mark.xfail
 def test_jax_phase_delay():
     jax = pytest.importorskip('jax')
     np = pytest.importorskip('jax.numpy')
@@ -19,8 +20,18 @@ def test_jax_phase_delay():
     lm = onp.random.random(size=(10, 2))*0.001
     frequency = np.linspace(.856e9, .856e9*2, 64, endpoint=True)
 
+    # Inputs should all be doubles
+    assert uvw.dtype == lm.dtype == frequency.dtype == np.float64
+
     # Compute complex phase
     complex_phase = jax.jit(phase_delay)(lm, uvw, frequency)
     np_complex_phase = np_phase_delay(lm, uvw, frequency)
 
-    onp.testing.assert_array_almost_equal(complex_phase, np_complex_phase)
+    onp.testing.assert_array_almost_equal(complex_phase, np_complex_phase,
+                                          decimal=5)
+
+    # numpy gets it right
+    assert np_complex_phase.dtype == np.complex128
+
+    # jax gets it wrong when jitting. expected failure here.
+    assert complex_phase.dtype == np.complex128

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if not on_rtd:
 extras_require = {
     'cuda': ['cupy >= 5.0.0', 'jinja2 >= 2.10'],
     'dask': ['dask[array] >= 0.18.0, < 0.20.0'],
+    'jax': ['jax == 0.1.15', 'jaxlib == 0.1.3'],
     'scipy': ['scipy >= 1.0.0'],
     'astropy': ['astropy >= 2.0.0, < 3.0.0' if PY2 else 'astropy >= 3.0.0'],
     'python-casacore': ['python-casacore >= 2.2.1'],


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
