### PR TITLE
Deal with constant precision in numba and jax phase_delay

### DIFF
--- a/africanus/__init__.py
+++ b/africanus/__init__.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import africanus.util.jax_init
+
 __author__ = """Simon Perkins"""
 __email__ = 'sperkins@ska.ac.za'
 __version__ = '0.1.2'

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -14,12 +14,20 @@ else:
     opt_import_error = None
 
 from africanus.constants import minus_two_pi_over_c
+import africanus.util.jax_init
 from africanus.util.requirements import requires_optional
 
 
 @requires_optional('jax', opt_import_error)
 def phase_delay(lm, uvw, frequency):
-    out_dtype = np.result_type(lm, uvw, frequency, np.complex64)
+    global minus_two_pi_over_c
+
+    const_type = np.result_type(lm, uvw, frequency)
+    out_dtype = np.result_type(const_type, np.complex64)
+
+    one = const_type.type(1.0)
+    complex_one = out_dtype.type(1j)
+    minus_two_pi_over_c = const_type.type(minus_two_pi_over_c)
 
     l = lm[:, 0, None, None]
     m = lm[:, 1, None, None]
@@ -28,10 +36,10 @@ def phase_delay(lm, uvw, frequency):
     v = uvw[None, :, 1, None]
     w = uvw[None, :, 2, None]
 
-    n = np.sqrt(1.0 - l**2 - m**2) - 1.0
+    n = np.sqrt(one - l**2 - m**2) - one
 
-    real_phase = l * u + m * v + n * w
-    real_phase = lm.dtype.type(minus_two_pi_over_c) * real_phase
+    real_phase = (l * u + m * v + n * w)
+    real_phase = minus_two_pi_over_c * real_phase
     real_phase *= frequency[None, None, :]
 
-    return np.exp(1j*real_phase)
+    return np.exp(complex_one*real_phase)

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -14,7 +14,6 @@ else:
     opt_import_error = None
 
 from africanus.constants import minus_two_pi_over_c
-import africanus.util.jax_init
 from africanus.util.requirements import requires_optional
 
 

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -19,12 +19,11 @@ from africanus.util.requirements import requires_optional
 
 @requires_optional('jax', opt_import_error)
 def phase_delay(lm, uvw, frequency):
-    const_type = np.result_type(lm, uvw, frequency)
-    out_dtype = np.result_type(const_type, np.complex64)
+    out_dtype = np.result_type(lm, uvw, frequency, np.complex64)
 
-    one = const_type.type(1.0)
+    one = lm.dtype.type(1.0)
+    neg_two_pi_over_c = lm.dtype.type(minus_two_pi_over_c)
     complex_one = out_dtype.type(1j)
-    neg_two_pi_over_c = const_type.type(minus_two_pi_over_c)
 
     l = lm[:, 0, None, None]
     m = lm[:, 1, None, None]

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -37,8 +37,8 @@ def phase_delay(lm, uvw, frequency):
 
     n = np.sqrt(one - l**2 - m**2) - one
 
-    real_phase = (l * u + m * v + n * w)
-    real_phase = minus_two_pi_over_c * real_phase
-    real_phase *= frequency[None, None, :]
+    real_phase = (minus_two_pi_over_c *
+                  (l * u + m * v + n * w) *
+                  frequency[None, None, :])
 
     return np.exp(complex_one*real_phase)

--- a/africanus/rime/jax/phase.py
+++ b/africanus/rime/jax/phase.py
@@ -19,14 +19,12 @@ from africanus.util.requirements import requires_optional
 
 @requires_optional('jax', opt_import_error)
 def phase_delay(lm, uvw, frequency):
-    global minus_two_pi_over_c
-
     const_type = np.result_type(lm, uvw, frequency)
     out_dtype = np.result_type(const_type, np.complex64)
 
     one = const_type.type(1.0)
     complex_one = out_dtype.type(1j)
-    minus_two_pi_over_c = const_type.type(minus_two_pi_over_c)
+    neg_two_pi_over_c = const_type.type(minus_two_pi_over_c)
 
     l = lm[:, 0, None, None]
     m = lm[:, 1, None, None]
@@ -37,7 +35,7 @@ def phase_delay(lm, uvw, frequency):
 
     n = np.sqrt(one - l**2 - m**2) - one
 
-    real_phase = (minus_two_pi_over_c *
+    real_phase = (neg_two_pi_over_c *
                   (l * u + m * v + n * w) *
                   frequency[None, None, :])
 

--- a/africanus/rime/phase.py
+++ b/africanus/rime/phase.py
@@ -11,13 +11,17 @@ import math
 import numba
 import numpy as np
 
-from ..constants import minus_two_pi_over_c
-from ..util.docs import DocstringTemplate, on_rtd
-from ..util.numba import is_numba_type_none
-from ..util.type_inference import infer_complex_dtype
+from africanus.constants import minus_two_pi_over_c
+from africanus.util.docs import DocstringTemplate, on_rtd
+from africanus.util.numba import is_numba_type_none
+from africanus.util.type_inference import infer_complex_dtype
 
 
 def phase_delay(lm, uvw, frequency):
+    # Bake constants in with the correct type
+    one = lm.dtype(1.0)
+    neg_two_pi_over_c = lm.dtype(minus_two_pi_over_c)
+
     out_dtype = infer_complex_dtype(lm, uvw, frequency)
 
     @wraps(phase_delay)
@@ -28,13 +32,13 @@ def phase_delay(lm, uvw, frequency):
         # For each source
         for source in range(lm.shape[0]):
             l, m = lm[source]
-            n = math.sqrt(1.0 - l**2 - m**2) - 1.0
+            n = math.sqrt(one - l**2 - m**2) - one
 
             # For each uvw coordinate
             for row in range(uvw.shape[0]):
                 u, v, w = uvw[row]
                 # e^(-2*pi*(l*u + m*v + n*w)/c)
-                real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
+                real_phase = neg_two_pi_over_c * (l * u + m * v + n * w)
 
                 # Multiple in frequency for each channel
                 for chan in range(frequency.shape[0]):

--- a/africanus/util/jax_init.py
+++ b/africanus/util/jax_init.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+"""
+Configure jax to use default 64 bit precision
+https://github.com/google/jax/issues/216
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    import jax.config
+except ImportError:
+    pass
+else:
+    jax.config.config.update("jax_enable_x64", True)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if not on_rtd:
 extras_require = {
     'cuda': ['cupy >= 5.0.0', 'jinja2 >= 2.10'],
     'dask': ['dask[array] >= 0.18.0, < 0.20.0'],
-    'jax': ['jax == 0.1.15', 'jaxlib == 0.1.3'],
+    'jax': ['jax == 0.1.16', 'jaxlib == 0.1.4'],
     'scipy': ['scipy >= 1.0.0'],
     'astropy': ['astropy >= 2.0.0, < 3.0.0' if PY2 else 'astropy >= 3.0.0'],
     'python-casacore': ['python-casacore >= 2.2.1'],


### PR DESCRIPTION
numba/jax need constants to be explicitly typed to avoid promotion to higher precision

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
