### PR TITLE
Introduce missing transpose in second antenna term of predict

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
+* Introduce transpose in second antenna term of predict (:pr:`72`)
 * cupy implement of `feed_rotation` (:pr:`67`)
 * cupy implemention of `stokes_convert` kernel (:pr:`65`)
 * Add a basic RIME example (:pr:`64`)

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -112,10 +112,10 @@ def jones_mul_factory(have_ants, have_bl, jones_type, accumulate):
                 a2_yx_H = np.conj(a2j[1, 0])
                 a2_yy_H = np.conj(a2j[1, 1])
 
-                xx = blj[0, 0] * a2_xx_H + blj[0, 1] * a2_yx_H
-                xy = blj[0, 0] * a2_xy_H + blj[0, 1] * a2_yy_H
-                yx = blj[1, 0] * a2_xx_H + blj[1, 1] * a2_yx_H
-                yy = blj[1, 0] * a2_xy_H + blj[1, 1] * a2_yy_H
+                xx = blj[0, 0] * a2_xx_H + blj[0, 1] * a2_xy_H
+                xy = blj[0, 0] * a2_yx_H + blj[0, 1] * a2_yy_H
+                yx = blj[1, 0] * a2_xx_H + blj[1, 1] * a2_xy_H
+                yy = blj[1, 0] * a2_yx_H + blj[1, 1] * a2_yy_H
 
                 if accumulate:
                     out[0, 0] += a1j[0, 0] * xx + a1j[0, 1] * yx
@@ -147,15 +147,15 @@ def jones_mul_factory(have_ants, have_bl, jones_type, accumulate):
                 a2_yy_H = np.conj(a2j[1, 1])
 
                 if accumulate:
-                    out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_yx_H
-                    out[0, 1] += a1j[0, 0] * a2_xy_H + a1j[0, 1] * a2_yy_H
-                    out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_yx_H
-                    out[1, 1] += a1j[1, 0] * a2_xy_H + a1j[1, 1] * a2_yy_H
+                    out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
+                    out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
+                    out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
+                    out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
                 else:
-                    out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_yx_H
-                    out[0, 1] += a1j[0, 0] * a2_xy_H + a1j[0, 1] * a2_yy_H
-                    out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_yx_H
-                    out[1, 1] += a1j[1, 0] * a2_xy_H + a1j[1, 1] * a2_yy_H
+                    out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
+                    out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
+                    out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
+                    out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
         else:
             raise ex
     elif not have_ants and have_bl:

--- a/africanus/rime/tests/test_predict.py
+++ b/africanus/rime/tests/test_predict.py
@@ -21,7 +21,7 @@ def rc(*a, **kw):
     ((1,), (1,), "srci,srci,srci->rci", "rci,rci,rci->rci"),
     ((2,), (1, 1), "srci,srci,srci->rci", "rci,rci,rci->rci"),
     ((2, 2), ((1, 0), (0, 1)),
-     "srcij,srcjk,srckl->rcil", "rcij,rcjk,rckl->rcil"),
+     "srcij,srcjk,srclk->rcil", "rcij,rcjk,rclk->rcil"),
 ])
 @pytest.mark.parametrize('a1j,blj,a2j', [
     [True, True, True],
@@ -95,7 +95,7 @@ def test_predict_vis(corr_shape, idm, einsum_sig1, einsum_sig2,
     ((1,), (1,), "srci,srci,srci->rci", "rci,rci,rci->rci"),
     ((2,), (1, 1), "srci,srci,srci->rci", "rci,rci,rci->rci"),
     ((2, 2), ((1, 0), (0, 1)),
-     "srcij,srcjk,srckl->rcil", "rcij,rcjk,rckl->rcil"),
+     "srcij,srcjk,srclk->rcil", "rcij,rcjk,rclk->rcil"),
 ])
 @pytest.mark.parametrize('a1j,blj,a2j', [
     [True, True, True],


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pycodestyle tests fail, the quickest way to correct
  this is to run `autopep8` and then `pycodestyle` to fix the
  remaining issues.

  ```
  $ pip install -U autopep8 pycodestyle
  $ autopep8 -r -i africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
