### PR TITLE
Time and channel averaging

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
+* Time and channel averaging (:pr:`75`)
 * cupy implementation of `predict_vis` (:pr:`73`)
 * Introduce transpose in second antenna term of predict (:pr:`72`)
 * cupy implementation of `feed_rotation` (:pr:`67`)

--- a/africanus/averaging/__init__.py
+++ b/africanus/averaging/__init__.py
@@ -1,1 +1,5 @@
+# -*- coding: utf-8 -*-
+
+__all__ = ["time_and_channel"]
+
 from africanus.averaging.time_and_channel_avg import time_and_channel

--- a/africanus/averaging/__init__.py
+++ b/africanus/averaging/__init__.py
@@ -1,0 +1,1 @@
+from africanus.averaging.time_and_channel_avg import time_and_channel

--- a/africanus/averaging/dask.py
+++ b/africanus/averaging/dask.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from operator import getitem
+
+from africanus.averaging.time_and_channel_avg import (
+                        time_and_channel as np_time_and_channel,
+                        TIME_AND_CHANNEL_DOCS)
+from africanus.util.requirements import requires_optional
+
+import numpy as np
+
+try:
+    import dask.array as da
+except ImportError as e:
+    dask_import_error = e
+else:
+    dask_import_error = None
+
+
+@requires_optional("dask.array", dask_import_error)
+def time_and_channel(time, ant1, ant2, vis, flags,
+                     avg_time=None, avg_chan=None,
+                     return_time=False,
+                     return_antenna=False):
+
+    adjust_chunks = {
+        # We're not really sure how many rows we'll end up with in each chunk
+        "row": tuple(np.nan for c in vis.chunks[0]),
+        # Channel averaging is more predictable
+        "chan": tuple((c + avg_chan - 1) // avg_chan for c in vis.chunks[1])
+    }
+
+    if return_time or return_antenna:
+        raise NotImplementedError("return of time and antenna is not "
+                                  "yet implemented in dask")
+
+    corr_dims = tuple("corr-%d" % i for i in range(len(vis.shape[2:])))
+
+    return da.blockwise(np_time_and_channel, ("row", "chan") + corr_dims,
+                        time, ("row",),
+                        ant1, ("row",),
+                        ant2, ("row",),
+                        vis, ("row", "chan") + corr_dims,
+                        flags, ("row", "chan") + corr_dims,
+                        avg_time=avg_time,
+                        avg_chan=avg_chan,
+                        return_time=return_time,
+                        return_antenna=return_antenna,
+                        adjust_chunks=adjust_chunks,
+                        dtype=vis.dtype)
+
+
+try:
+    time_and_channel.__doc__ = TIME_AND_CHANNEL_DOCS.substitute(
+                                    array_type=":class:`dask.array.Array`")
+except AttributeError:
+    pass

--- a/africanus/averaging/dask.py
+++ b/africanus/averaging/dask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from operator import getitem
-
 from africanus.averaging.time_and_channel_avg import (
                         time_and_channel as np_time_and_channel,
                         TIME_AND_CHANNEL_DOCS)

--- a/africanus/averaging/dask.py
+++ b/africanus/averaging/dask.py
@@ -12,11 +12,22 @@ from africanus.util.requirements import requires_optional
 import numpy as np
 
 try:
+    from dask.base import tokenize
     import dask.array as da
+    import dask.blockwise as db
+    from dask.highlevelgraph import HighLevelGraph
 except ImportError as e:
     dask_import_error = e
 else:
     dask_import_error = None
+
+
+def _getitem_tup(array, d, n):
+    """ Recursively index a sequence d times and return element n"""
+    for i in range(d):
+        array = array[0]
+
+    return array[n]
 
 
 @requires_optional("dask.array", dask_import_error)
@@ -25,31 +36,158 @@ def time_and_channel(time, ant1, ant2, vis, flags,
                      return_time=False,
                      return_antenna=False):
 
-    adjust_chunks = {
-        # We're not really sure how many rows we'll end up with in each chunk
-        "row": tuple(np.nan for c in vis.chunks[0]),
-        # Channel averaging is more predictable
-        "chan": tuple((c + avg_chan - 1) // avg_chan for c in vis.chunks[1])
-    }
-
-    if return_time or return_antenna:
-        raise NotImplementedError("return of time and antenna is not "
-                                  "yet implemented in dask")
+    # We're not really sure how many rows we'll end up with in each chunk
+    row_chunks = tuple(np.nan for c in vis.chunks[0])
+    # Channel averaging is more predictable
+    chan_chunks = tuple((c + avg_chan - 1) // avg_chan for c in vis.chunks[1])
 
     corr_dims = tuple("corr-%d" % i for i in range(len(vis.shape[2:])))
+    vis_dims = ("row", "chan") + corr_dims
 
-    return da.blockwise(np_time_and_channel, ("row", "chan") + corr_dims,
-                        time, ("row",),
-                        ant1, ("row",),
-                        ant2, ("row",),
-                        vis, ("row", "chan") + corr_dims,
-                        flags, ("row", "chan") + corr_dims,
-                        avg_time=avg_time,
-                        avg_chan=avg_chan,
-                        return_time=return_time,
-                        return_antenna=return_antenna,
-                        adjust_chunks=adjust_chunks,
-                        dtype=vis.dtype)
+    token = tokenize(time, ant1, ant2, vis, flags, avg_time, avg_chan)
+    tc_name = "time-and-channel-" + token
+
+    layers = db.blockwise(np_time_and_channel, tc_name, vis_dims,
+                          time.name, ("row",),
+                          ant1.name, ("row",),
+                          ant2.name, ("row",),
+                          vis.name, vis_dims,
+                          flags.name, vis_dims,
+                          avg_time=avg_time,
+                          avg_chan=avg_chan,
+                          return_time=return_time,
+                          return_antenna=return_antenna,
+                          numblocks={
+                            time.name: time.numblocks,
+                            ant1.name: ant1.numblocks,
+                            ant2.name: ant2.numblocks,
+                            vis.name: vis.numblocks,
+                            flags.name: flags.numblocks,
+                          })
+
+    deps = (time, ant1, ant2, vis, flags)
+    graph = HighLevelGraph.from_collections(tc_name, layers, deps)
+
+    if not return_time and not return_antenna:
+        vis_chunks = (row_chunks, chan_chunks) + vis.chunks[2:]
+        return da.Array(graph, tc_name, vis_chunks, dtype=vis.dtype)
+    elif return_time and not return_antenna:
+        # Create an array extracting visibilities out of the tuple
+        name0 = "time-and-channel-getitem0-" + tokenize(token, 0)
+        layers0 = db.blockwise(_getitem_tup, name0, vis_dims,
+                               tc_name, vis_dims,
+                               0, None,
+                               0, None,
+                               numblocks={
+                                tc_name: vis.numblocks
+                               })
+        graph0 = HighLevelGraph.from_collections(name0, layers0, ())
+        graph0 = HighLevelGraph.merge(graph, graph0)
+        vis_chunks = (row_chunks, chan_chunks) + vis.chunks[2:]
+        vis = da.Array(graph0, name0, vis_chunks, dtype=vis.dtype)
+
+        nextra_blocks = len(vis.numblocks[1:])
+        extra_blocks = (1,)*nextra_blocks
+        numblocks = {tc_name: (vis.numblocks[0],) + extra_blocks}
+
+        name1 = "time-and-channel-getitem1-" + tokenize(token, 1)
+        layers1 = db.blockwise(_getitem_tup, name1, ("row",),
+                               tc_name, vis_dims,
+                               nextra_blocks, None,
+                               1, None,
+                               numblocks=numblocks)
+        graph1 = HighLevelGraph.from_collections(name1, layers1, ())
+        graph1 = HighLevelGraph.merge(graph, graph1)
+        time = da.Array(graph1, name1, (vis.chunks[0],), dtype=time.dtype)
+
+        return vis, time
+    elif not return_time and return_antenna:
+        # Create an array extracting visibilities out of the tuple
+        name0 = "time-and-channel-getitem0-" + tokenize(token, 0)
+        layers0 = db.blockwise(_getitem_tup, name0, vis_dims,
+                               tc_name, vis_dims,
+                               0, None,
+                               0, None,
+                               numblocks={
+                                tc_name: vis.numblocks
+                               })
+        graph0 = HighLevelGraph.from_collections(name0, layers0, ())
+        graph0 = HighLevelGraph.merge(graph, graph0)
+        vis_chunks = (row_chunks, chan_chunks) + vis.chunks[2:]
+        vis = da.Array(graph0, name0, vis_chunks, dtype=vis.dtype)
+
+        name1 = "time-and-channel-getitem1-" + tokenize(token, 1)
+        layers1 = db.blockwise(_getitem_tup, name1, ("row",),
+                               tc_name, vis_dims,
+                               nextra_blocks, None,
+                               1, None,
+                               numblocks=numblocks)
+        graph1 = HighLevelGraph.from_collections(name1, layers1, ())
+        graph1 = HighLevelGraph.merge(graph, graph1)
+        ant1 = da.Array(graph1, name1, (vis.chunks[0],), dtype=ant1.dtype)
+
+        name2 = "time-and-channel-getitem2-" + tokenize(token, 2)
+        layers2 = db.blockwise(_getitem_tup, name2, ("row",),
+                               tc_name, vis_dims,
+                               nextra_blocks, None,
+                               2, None,
+                               numblocks=numblocks)
+        graph2 = HighLevelGraph.from_collections(name1, layers2, ())
+        graph2 = HighLevelGraph.merge(graph, graph2)
+        ant2 = da.Array(graph2, name2, (vis.chunks[0],), dtype=ant1.dtype)
+
+        return vis, ant1, ant2
+
+    elif return_time and return_antenna:
+        # Create an array extracting visibilities out of the tuple
+        name0 = "time-and-channel-getitem0-" + tokenize(token, 0)
+        layers0 = db.blockwise(_getitem_tup, name0, vis_dims,
+                               tc_name, vis_dims,
+                               0, None,
+                               0, None,
+                               numblocks={
+                                tc_name: vis.numblocks
+                               })
+        graph0 = HighLevelGraph.from_collections(name0, layers0, ())
+        graph0 = HighLevelGraph.merge(graph, graph0)
+        vis_chunks = (row_chunks, chan_chunks) + vis.chunks[2:]
+        vis = da.Array(graph0, name0, vis_chunks, dtype=vis.dtype)
+
+        nextra_blocks = len(vis.numblocks[1:])
+        extra_blocks = (1,)*nextra_blocks
+        numblocks = {tc_name: (vis.numblocks[0],) + extra_blocks}
+
+        name1 = "time-and-channel-getitem1-" + tokenize(token, 1)
+        layers1 = db.blockwise(_getitem_tup, name1, ("row",),
+                               tc_name, vis_dims,
+                               nextra_blocks, None,
+                               1, None,
+                               numblocks=numblocks)
+        graph1 = HighLevelGraph.from_collections(name1, layers1, ())
+        graph1 = HighLevelGraph.merge(graph, graph1)
+        time = da.Array(graph1, name1, (vis.chunks[0],), dtype=time.dtype)
+
+        name2 = "time-and-channel-getitem2-" + tokenize(token, 2)
+        layers2 = db.blockwise(_getitem_tup, name2, ("row",),
+                               tc_name, vis_dims,
+                               nextra_blocks, None,
+                               2, None,
+                               numblocks=numblocks)
+        graph2 = HighLevelGraph.from_collections(name1, layers2, ())
+        graph2 = HighLevelGraph.merge(graph, graph2)
+        ant1 = da.Array(graph2, name2, (vis.chunks[0],), dtype=ant1.dtype)
+
+        name3 = "time-and-channel-getitem3-" + tokenize(token, 3)
+        layers3 = db.blockwise(_getitem_tup, name3, ("row",),
+                               tc_name, vis_dims,
+                               nextra_blocks, None,
+                               3, None,
+                               numblocks=numblocks)
+        graph3 = HighLevelGraph.from_collections(name1, layers3, ())
+        graph3 = HighLevelGraph.merge(graph, graph3)
+        ant2 = da.Array(graph3, name3, (vis.chunks[0],), dtype=ant2.dtype)
+
+        return vis, time, ant1, ant2
 
 
 try:

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import pytest
+
+
+def test_time_and_channel_averaging():
+    from africanus.averaging import time_and_channel
+
+    time = np.asarray([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0])  # noqa
+    ant1 = np.asarray([  0,   0,   1,   0,   0,   1,   2,   0,   0,   1])  # noqa
+    ant2 = np.asarray([  1,   2,   2,   0,   1,   2,   3,   0,   1,   2])  # noqa
+
+    row = time.shape[0]
+    chan = 17
+    corr = 4
+
+    vis = (np.arange(row*chan*corr, dtype=np.float32) +
+           np.arange(1, row*chan*corr+1, dtype=np.float32)*1j)
+
+    vis = vis.reshape((row, chan, corr))
+    avg_vis = time_and_channel(time, ant1, ant2, vis, time_bins=2, chan_bins=4)
+
+    assert vis.sum() == avg_vis.sum()

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -21,7 +21,7 @@ def test_time_and_channel_averaging(corrs):
     ant2 = np.asarray([1,   2,   2,   0,   1,   2,   3,   0,   1,   2])    # noqa
 
     row = time.shape[0]
-    chan = 17
+    chan = 5
     fcorrs = reduce(mul, corrs, 1)
 
     vis = (np.arange(row*chan*fcorrs, dtype=np.float32) +
@@ -29,9 +29,21 @@ def test_time_and_channel_averaging(corrs):
 
     vis = vis.reshape((row, chan) + corrs)
 
+    # Test no averaging case
     avg_vis, avg_time, avg_ant1, avg_ant2 = time_and_channel(
                                 time, ant1, ant2, vis,
-                                time_bins=2, chan_bins=4,
+                                avg_time=None, avg_chan=None,
+                                return_time=True, return_antenna=True)
+
+    np.testing.assert_array_almost_equal(avg_ant1, ant1)
+    np.testing.assert_array_almost_equal(avg_ant2, ant2)
+    np.testing.assert_array_almost_equal(avg_time, time)
+    np.testing.assert_array_almost_equal(avg_vis, vis)
+
+    # Now do some averaging
+    avg_vis, avg_time, avg_ant1, avg_ant2 = time_and_channel(
+                                time, ant1, ant2, vis,
+                                avg_time=2, avg_chan=2,
                                 return_time=True, return_antenna=True)
 
     np.testing.assert_array_almost_equal(avg_time,
@@ -44,3 +56,4 @@ def test_time_and_channel_averaging(corrs):
     assert vis.shape[2:] == avg_vis.shape[2:] == corrs
 
     assert vis.sum() == avg_vis.sum()
+

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -4,25 +4,43 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from operator import mul
+
 import numpy as np
 import pytest
 
+from africanus.compatibility import reduce
 
-def test_time_and_channel_averaging():
+
+@pytest.mark.parametrize("corrs", [(1,), (2,), (2, 2)])
+def test_time_and_channel_averaging(corrs):
     from africanus.averaging import time_and_channel
 
     time = np.asarray([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0])  # noqa
-    ant1 = np.asarray([  0,   0,   1,   0,   0,   1,   2,   0,   0,   1])  # noqa
-    ant2 = np.asarray([  1,   2,   2,   0,   1,   2,   3,   0,   1,   2])  # noqa
+    ant1 = np.asarray([0,   0,   1,   0,   0,   1,   2,   0,   0,   1])    # noqa
+    ant2 = np.asarray([1,   2,   2,   0,   1,   2,   3,   0,   1,   2])    # noqa
 
     row = time.shape[0]
     chan = 17
-    corr = 4
+    fcorrs = reduce(mul, corrs, 1)
 
-    vis = (np.arange(row*chan*corr, dtype=np.float32) +
-           np.arange(1, row*chan*corr+1, dtype=np.float32)*1j)
+    vis = (np.arange(row*chan*fcorrs, dtype=np.float32) +
+           np.arange(1, row*chan*fcorrs+1, dtype=np.float32)*1j)
 
-    vis = vis.reshape((row, chan, corr))
-    avg_vis = time_and_channel(time, ant1, ant2, vis, time_bins=2, chan_bins=4)
+    vis = vis.reshape((row, chan) + corrs)
+
+    avg_vis, avg_time, avg_ant1, avg_ant2 = time_and_channel(
+                                time, ant1, ant2, vis,
+                                time_bins=2, chan_bins=4,
+                                return_time=True, return_antenna=True)
+
+    np.testing.assert_array_almost_equal(avg_time,
+                                         [1.0, 1.5, 1.5, 2.0, 2.5, 3.0, 3.0])
+
+    np.testing.assert_array_almost_equal(avg_ant1, [0, 0, 1, 2, 0, 0, 1])
+    np.testing.assert_array_almost_equal(avg_ant2, [2, 1, 2, 3, 0, 1, 2])
+
+    # Same correlation shape
+    assert vis.shape[2:] == avg_vis.shape[2:] == corrs
 
     assert vis.sum() == avg_vis.sum()

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -28,10 +28,11 @@ def test_time_and_channel_averaging(corrs):
            np.arange(1, row*chan*fcorrs+1, dtype=np.float32)*1j)
 
     vis = vis.reshape((row, chan) + corrs)
+    flags = np.zeros(vis.shape, dtype=np.uint8)
 
     # Test no averaging case
     avg_vis, avg_time, avg_ant1, avg_ant2 = time_and_channel(
-                                time, ant1, ant2, vis,
+                                time, ant1, ant2, vis, flags,
                                 avg_time=None, avg_chan=None,
                                 return_time=True, return_antenna=True)
 
@@ -42,7 +43,7 @@ def test_time_and_channel_averaging(corrs):
 
     # Now do some averaging
     avg_vis, avg_time, avg_ant1, avg_ant2 = time_and_channel(
-                                time, ant1, ant2, vis,
+                                time, ant1, ant2, vis, flags,
                                 avg_time=2, avg_chan=2,
                                 return_time=True, return_antenna=True)
 

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -77,7 +77,9 @@ def test_time_and_channel_averaging(time, ant1, ant2, vis, corrs):
     # Same correlation shape
     assert vis.shape[2:] == avg_vis.shape[2:] == corrs
 
-    assert vis.sum() == avg_vis.sum()
+    # This works if we comment out both time and channel
+    # bin normalisation in time_and_channel
+    # assert vis.sum() == avg_vis.sum()
 
 
 @pytest.mark.parametrize("corrs", [(1,), (2,), (2, 2)])

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -243,7 +243,7 @@ def time_and_channel(time, ant1, ant2, vis, flags,
         corrs = vis.shape[2:]
         fcorr = reduce(mul, vis.shape[2:], 1)
         flat_vis = vis.reshape(vis.shape[:2] + (fcorr,))
-        flat_flags = flags.reshape(vis.shape[:2] + (fcorr,))
+        flat_flags = flags.reshape(flags.shape[:2] + (fcorr,))
     else:
         corrs = vis.shape[2:]
         flat_vis = vis

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from africanus.util.docs import DocstringTemplate
+
+import numpy as np
+import numba
+
+
+@numba.njit(nogil=True, cache=True)
+def _time_and_chan_avg(time, vis, utime, time_inv, ubl, bl_inv,
+                       time_bins, chan_bins):
+
+    if len(vis.shape) != 3:
+        raise ValueError("visibilities must have shape (row, chan, corr)")
+
+    nbl = ubl.shape[0]
+    ntime = utime.shape[0]
+    nchan = vis.shape[1]
+    ncorr = vis.shape[2]
+
+    # Create a bl x time mask representing the full
+    # resolution matrix possible for this chunk of rows
+    mask = np.full((nbl, ntime), -1, dtype=np.int32)
+
+    # Fill mask indicating presence of row data
+    for r in range(vis.shape[0]):
+        ti = time_inv[r]
+        bli = bl_inv[r]
+        mask[bli, ti] = r
+
+    # Determine averaging across time and channel
+    # (same as number of elements in each bin)
+    avg_times = time_bin_size = (ntime + time_bins - 1) // time_bins
+    avg_chans = chan_bin_size = (nchan + chan_bins - 1) // chan_bins
+
+    # Create a lookup table of averaged times for each baseline,
+    # used to order visibilities in the output data.
+    # time_sentinel, indicating absence of data,
+    # set to maximum floating point value so that
+    # missing data is moved to the end during an argsort of the lookup
+    time_sentinel = np.finfo(time.dtype).max
+    lookup_shape = (nbl, time_bins)
+    lookup = np.full(lookup_shape, time_sentinel, dtype=time.dtype)
+
+    # Number of output rows
+    out_rows = 0
+
+    # For each baseline, average associated times
+    for bli in range(ubl.shape[0]):
+        tbin = numba.int32(0)         # Time averaging bin
+        valid_times = numba.int32(0)  # Number of time samples
+
+        for ti in range(utime.shape[0]):
+            r = mask[bli, ti]
+
+            # Ignore non-existent entries
+            if r == -1:
+                continue
+
+            # If we encounter the sentinel value, just assign
+            # otherwise add the value to the bin
+            if lookup[bli, tbin] == time_sentinel:
+                lookup[bli, tbin] = time[r]
+            else:
+                lookup[bli, tbin] += time[r]
+
+            valid_times += 1
+
+            # If we've completely filled the time averaging bin,
+            # normalise it and advance to the next
+            if valid_times == time_bin_size:
+                lookup[bli, tbin] /= valid_times
+                tbin += 1
+                valid_times = 0
+
+        # Handle normalisation of the last bin
+        if valid_times > 0:
+            lookup[bli, tbin] /= valid_times
+            tbin += 1
+
+        # Add number of bins to the output rows
+        out_rows += tbin
+
+    # Sort the averaged time values to determine their
+    # location in the output. We use mergesort so that the
+    # sort is stable.
+    argsort = np.argsort(lookup.ravel(), kind='mergesort')
+    inv_argsort = np.empty_like(argsort)
+
+    for i, a in enumerate(argsort):
+        inv_argsort[a] = i
+
+    # print(argsort)
+    # print(inv_argsort)
+
+    # Allocate output
+    output = np.zeros((out_rows, chan_bins, ncorr), dtype=vis.dtype)
+
+    # print(output.shape, lookup.shape, argsort.shape)
+
+    # For each baseline, average the visibility data
+    # along the channel and time dimensions
+    for bli in range(nbl):
+        tbin = numba.int32(0)         # Time averaging bin
+        valid_times = numba.int32(0)  # Number of time samples
+        bl_off = bli*time_bins        # Offset of this baseline in flat lookup
+        orow = argsort.dtype.type(0)  # Output row
+
+        for ti in range(ntime):
+            r = mask[bli, ti]
+
+            # Ignore missing values
+            if r == -1 or lookup[bli, tbin] == time_sentinel:
+                continue
+
+            orow = inv_argsort[bl_off + tbin]
+
+            for c in range(ncorr):
+                cbin = numba.int32(0)        # Channel averaging bin
+                chan_count = numba.int32(0)  # Counter variable
+
+                for f in range(nchan):
+                    output[orow, cbin, c] += vis[r, f, c]
+                    chan_count += 1
+
+                    # If we've completely filled the channel bin
+                    # normalise by channel count
+                    if chan_count == chan_bin_size:
+                        # output[orow, cbin, c] /= chan_count
+                        chan_count = 0
+                        cbin += 1
+
+                # Normalise any remaining data in the last channel bin
+                if chan_count > 0:
+                    # output[orow, cbin, c] /= chan_count
+                    # chan_count = 0
+                    # cbin += 1
+                    pass
+
+            valid_times += 1
+
+            # If we've completely filled the time bin
+            # normalise by time count
+            if valid_times == time_bin_size:
+                # for f in range(chan_bins):
+                #     for c in range(ncorr):
+                #         output[orow, f, c] /= valid_times
+
+                valid_times = 0
+                tbin += 1
+                pass
+
+        # Normalise any remaining data in the last time bin
+        if valid_times > 0:
+            # for f in range(chan_bins):
+            #     for c in range(ncorr):
+            #         output[orow, f, c] /= valid_times
+
+            # valid_times = 0
+            # tbin += 1
+            pass
+
+    return output
+
+
+def time_and_channel(time, ant1, ant2, vis, time_bins=1, chan_bins=1):
+    utime, time_inv = np.unique(time, return_inverse=True)
+    bl = np.stack([ant1, ant2], axis=1)
+    ubl, bl_inv = np.unique(bl, axis=0, return_inverse=True)
+
+    return _time_and_chan_avg(time, vis,
+                              utime, time_inv, ubl, bl_inv,
+                              time_bins, chan_bins)
+
+
+TIME_AND_CHANNEL_DOCS = DocstringTemplate("""
+Average visibility data over time and channel.
+
+Parameters
+----------
+time : $(array_type)
+    time data of shape :code:`(row,)`
+antenna1 : $(array_type)
+    antenna1 of shape :code:`(row,)`
+antenna2 : $(array_type)
+    antenna2 of shape :code:`(row,)`
+vis : $(array_type)
+    visibility data of shape :code:`(row, chan, corr)`
+time_bins : int, optional
+    Defaults to 1
+chan_bins : int, optional
+    Defaults to 1
+
+Returns
+-------
+averaged_visibilities : $(array_type)
+    Averaged visibilities of shape :code:`(row, chan, corr)`
+
+""")
+
+
+try:
+    time_and_channel.__doc__ = TIME_AND_CHANNEL_DOCS.substitute(
+                                    array_type=":class:`numpy.ndarray`")
+except AttributeError:
+    pass

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -173,14 +173,14 @@ def _time_and_chan_avg(time, ant1, ant2, vis, flags,
                     # If we've completely filled the channel bin
                     # normalise by the channel count
                     if chan_counts[c] == chan_bin_size:
-                        # scratch[cbins[c], c] /= chan_counts[c]
+                        scratch[cbins[c], c] /= chan_counts[c]
                         chan_counts[c] = 0
                         cbins[c] += 1
 
             # Normalise any remaining data in the last channel bin
             for c in range(ncorr):
                 if chan_counts[c] > 0:
-                    # scratch[cbins[c], c] /= chan_counts[c]
+                    scratch[cbins[c], c] /= chan_counts[c]
                     chan_counts[c] = 0
                     cbins[c] += 1
 
@@ -198,18 +198,18 @@ def _time_and_chan_avg(time, ant1, ant2, vis, flags,
             # If we've completely filled the time bin
             # normalise by time count
             if valid_times == time_bin_size:
-                # for f in range(chan_bins):
-                #     for c in range(ncorr):
-                #         output[orow, f, c] /= valid_times
+                for f in range(chan_bins):
+                    for c in range(ncorr):
+                        output[orow, f, c] /= valid_times
 
                 valid_times = 0
                 tbin += 1
 
         # Normalise any remaining data in the last time bin
         if valid_times > 0:
-            # for f in range(chan_bins):
-            #     for c in range(ncorr):
-            #         output[orow, f, c] /= valid_times
+            for f in range(chan_bins):
+                for c in range(ncorr):
+                    output[orow, f, c] /= valid_times
 
             valid_times = 0
             tbin += 1

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -21,9 +21,6 @@ def _time_and_chan_avg(time, ant1, ant2, vis,
                        return_time=False,
                        return_antenna=False):
 
-    if len(vis.shape) != 3:
-        raise ValueError("visibilities must have shape (row, chan, corr)")
-
     nbl = ubl.shape[0]
     ntime = utime.shape[0]
     nchan = vis.shape[1]
@@ -146,9 +143,8 @@ def _time_and_chan_avg(time, ant1, ant2, vis,
                 # Normalise any remaining data in the last channel bin
                 if chan_count > 0:
                     # output[orow, cbin, c] /= chan_count
-                    # chan_count = 0
-                    # cbin += 1
-                    pass
+                    chan_count = 0
+                    cbin += 1
 
             valid_times += 1
 
@@ -161,7 +157,6 @@ def _time_and_chan_avg(time, ant1, ant2, vis,
 
                 valid_times = 0
                 tbin += 1
-                pass
 
         # Normalise any remaining data in the last time bin
         if valid_times > 0:
@@ -169,9 +164,8 @@ def _time_and_chan_avg(time, ant1, ant2, vis,
             #     for c in range(ncorr):
             #         output[orow, f, c] /= valid_times
 
-            # valid_times = 0
-            # tbin += 1
-            pass
+            valid_times = 0
+            tbin += 1
 
     return_shape = output.shape[:2] + corr_shape
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,7 @@ API
     deconv-api.rst
     coordinates-api.rst
     model-api.rst
+    averaging-api.rst
     util-api.rst
 
 

--- a/docs/averaging-api.rst
+++ b/docs/averaging-api.rst
@@ -15,3 +15,14 @@ Numpy
 
 .. autofunction:: time_and_channel
 
+
+Dask
+~~~~
+
+.. currentmodule:: africanus.averaging.dask
+
+.. autosummary::
+    time_and_channel
+
+.. autofunction:: time_and_channel
+

--- a/docs/averaging-api.rst
+++ b/docs/averaging-api.rst
@@ -1,0 +1,17 @@
+---------
+Averaging
+---------
+
+Routines for averaging visibility data.
+
+
+Numpy
+~~~~~
+
+.. currentmodule:: africanus.averaging
+
+.. autosummary::
+    time_and_channel
+
+.. autofunction:: time_and_channel
+


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
