### PR TITLE
Support complete and complete-cuda in extras_require

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
-* Support `complete` and `complete-cuda` to support non-GPU installs.
+* Support `complete` and `complete-cuda` to support non-GPU installs (:pr:`87`)
 * Gaussian Shape Parameter Implementation (:pr:`82`, :pr:`83`)
 * Compare predict versus MeqTrees (:pr:`79`)
 * Time and channel averaging (:pr:`75`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.3 (2018-03-28)
 ------------------
+* Support `complete` and `complete-cuda` to support non-GPU installs.
 * Gaussian Shape Parameter Implementation (:pr:`82`, :pr:`83`)
 * Compare predict versus MeqTrees (:pr:`79`)
 * Time and channel averaging (:pr:`75`)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,11 +34,18 @@ as follows:
     $ pip install codex-africanus[python-casacore]
 
 
-To install the complete set of dependencies:
+To install the complete set of dependencies for the CPU:
 
 .. code-block:: console
 
     $ pip install codex-africanus[complete]
+
+To install the complete set of dependencies including CUDA:
+
+.. code-block:: console
+
+    $ pip install codex-africanus[complete-cuda]
+
 
 .. _pip: https://pip.pypa.io
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,11 @@ extras_require = {
     'testing': ['pytest', 'pytest-runner']
 }
 
-extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
+_non_cuda_extras = [er for n, er in extras_require.items() if n != "cuda"]
+_all_extras = extras_require.values()
+
+extras_require['complete'] = sorted(set(sum(_non_cuda_extras, [])))
+extras_require['complete-cuda'] = sorted(set(sum(_all_extras, [])))
 
 setup_requirements = ['pytest-runner', ]
 test_requirements = (['pytest'] +


### PR DESCRIPTION
so that users aren't forced to install cupy for non-GPU machines

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
