### PR TITLE
Fix ratio computation in gauss_shape

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.1.5 (YYYY-MM-DD)
+------------------
+* Fix ratio computation in Gaussian Shape (:pr:`89`)
+
 0.1.4 (2019-03-11)
 ------------------
 * Support `complete` and `complete-cuda` to support non-GPU installs (:pr:`87`)

--- a/africanus/model/shape/gaussian_shape.py
+++ b/africanus/model/shape/gaussian_shape.py
@@ -35,7 +35,7 @@ def gaussian(uvw, frequency, shape_params):
 
             el = emaj * np.sin(angle)
             em = emaj * np.cos(angle)
-            er = emaj / (1.0 if emin == 0.0 else emin)
+            er = emin / (1.0 if emaj == 0.0 else emaj)
 
             for r in range(uvw.shape[0]):
                 u, v, w = uvw[r]


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
