### PR TITLE
Fix ratio in gaussian docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.1.5 (YYYY-MM-DD)
 ------------------
-* Fix ratio computation in Gaussian Shape (:pr:`89`)
+* Fix ratio computation in Gaussian Shape (:pr:`89`, :pr:`90`)
 
 0.1.4 (2019-03-11)
 ------------------

--- a/africanus/model/shape/gaussian_shape.py
+++ b/africanus/model/shape/gaussian_shape.py
@@ -60,7 +60,7 @@ Computes the Gaussian Shape Function.
 .. math::
 
     & \lambda^\prime = 2 \lambda \pi \\
-    & r = \frac{e_{maj}}{e_{min}} \\
+    & r = \frac{e_{min}}{e_{maj}} \\
     & u_{1} = (u \, e_{maj} \, cos(\alpha) - v \, e_{maj} \, sin(\alpha))
       r \lambda^\prime \\
     & v_{1} = (u \, e_{maj} \, sin(\alpha) - v \, e_{maj} \, cos(\alpha))


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
