### PR TITLE
Allow flexibility in wsclean column defs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.1.5 (YYYY-MM-DD)
 ------------------
-* Support integer seconds in wsclean ra and dec columns
+* Support integer seconds in wsclean ra and dec columns (:pr:`91`, :pr:`93`)
 * Fix ratio computation in Gaussian Shape (:pr:`89`, :pr:`90`)
 
 0.1.4 (2019-03-11)

--- a/africanus/model/wsclean/file_model.py
+++ b/africanus/model/wsclean/file_model.py
@@ -58,19 +58,19 @@ def _deg_converter(deg_str):
     return 2.0 * math.pi * value
 
 
-_COLUMN_CONVERTERS = [
-    ('Name', str),
-    ('Type', str),
-    ('Ra', _hour_converter),
-    ('Dec', _deg_converter),
-    ('I', float),
-    ('SpectralIndex', literal_eval),
-    ('LogarithmicSI', lambda x: bool(x == "true")),
-    ('ReferenceFrequency', float),
-    ('MajorAxis', float),
-    ('MinorAxis', float),
-    ('Orientation', float),
-]
+_COLUMN_CONVERTERS = {
+    'Name': str,
+    'Type': str,
+    'Ra': _hour_converter,
+    'Dec': _deg_converter,
+    'I': float,
+    'SpectralIndex': literal_eval,
+    'LogarithmicSI': lambda x: bool(x == "true"),
+    'ReferenceFrequency': float,
+    'MajorAxis': float,
+    'MinorAxis': float,
+    'Orientation': float,
+}
 
 
 # Split on commas, ignoring within [] brackets
@@ -203,11 +203,11 @@ def load(filename):
                              % filename)
 
         column_names, defaults = _parse_header(header)
-        conv_names, converters = zip(*_COLUMN_CONVERTERS)
 
-        if not conv_names == tuple(column_names):
-            raise ValueError("header columns '%s' do not match expected '%s'"
-                             % (conv_names, column_names))
+        try:
+            converters = [_COLUMN_CONVERTERS[n] for n in column_names]
+        except KeyError as e:
+            raise ValueError("No converter registered for column %s" % str(e))
 
         return _parse_lines(fh, line_nr, column_names, defaults, converters)
     finally:


### PR DESCRIPTION
Don't insist that they're all there

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
