### PR TITLE
Support frequency and bandwidth averaging

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.5 (YYYY-MM-DD)
 ------------------
+* Support frequency and bandwidth averaging (:pr:`97`)
 * Fix radec sign conversion in wsclean sky model (:pr:`96`)
 * Full Time and Channel Averaging Implementation (:pr:`80`)
 * Support integer seconds in wsclean ra and dec columns (:pr:`91`, :pr:`93`)

--- a/docs/averaging-api.rst
+++ b/docs/averaging-api.rst
@@ -135,6 +135,8 @@ FLAG_ROW        Effective         Set if All Inputs Flagged    No
 UVW             Effective         Mean                         No
 WEIGHT          Effective         Mean                         No
 SIGMA           Effective         Mean                         No
+CHAN_FREQ       Nominal           Mean                         No
+CHAN_WIDTH      Nominal           Sum                          No
 DATA (vis)      Effective         Mean of Circular Quantities  No
 FLAG            Effective         Set if All Inputs Flagged    No
 WEIGHT_SPECTRUM Effective         Mean                         No


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
