### PR TITLE
Remove numpy wrappers from DFT kernels

### DIFF
--- a/africanus/dft/kernels.py
+++ b/africanus/dft/kernels.py
@@ -11,75 +11,99 @@ import numpy as np
 
 from africanus.constants import minus_two_pi_over_c
 from africanus.util.docs import doc_tuple_to_str
+from africanus.util.numba import is_numba_type_none, generated_jit
 
 
-@numba.jit(nopython=True, nogil=True, cache=True)
-def _im_to_vis_impl(image, uvw, lm, frequency, vis_of_im):
-    # For each uvw coordinate
-    for row in range(uvw.shape[0]):
-        u, v, w = uvw[row]
+@generated_jit(nopython=True, nogil=True, cache=True)
+def im_to_vis(image, uvw, lm, frequency, dtype=None):
+    # Infer complex output dtype if none provided
+    if is_numba_type_none(dtype):
+        out_dtype = np.result_type(np.complex64,
+                                   *(np.dtype(a.dtype.name) for a in
+                                     (image, uvw, lm, frequency)))
+    else:
+        out_dtype = dtype.dtype
 
-        # For each source
-        for source in range(lm.shape[0]):
-            l, m = lm[source]
-            n = np.sqrt(1.0 - l**2 - m**2) - 1.0
+    def _im_to_vis_impl(image, uvw, lm, frequency, dtype=None):
+        vis_of_im = np.zeros((uvw.shape[0], frequency.shape[0]),
+                             dtype=out_dtype)
 
-            # e^(-2*pi*(l*u + m*v + n*w)/c)
-            real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
-
-            # Multiple in frequency for each channel
-            for chan in range(frequency.shape[0]):
-                p = real_phase * frequency[chan] * 1.0j
-
-                # Our phase input is purely imaginary
-                # so we can can elide a call to exp
-                # and just compute the cos and sin
-                # @simon does this really make a difference?
-                # I thought a complex exponential is evaluated
-                # as a sum of sin and cos anyway
-                vis_of_im[row, chan] += np.exp(p)*image[source, chan]
-
-    return vis_of_im
-
-
-@numba.jit(nopython=True, nogil=True, cache=True)
-def _vis_to_im_impl(vis, uvw, lm, frequency, im_of_vis):
-    # For each source
-    for source in range(lm.shape[0]):
-        l, m = lm[source]
-        n = np.sqrt(1.0 - l ** 2 - m ** 2) - 1.0
         # For each uvw coordinate
         for row in range(uvw.shape[0]):
             u, v, w = uvw[row]
 
-            # e^(-2*pi*(l*u + m*v + n*w)/c)
-            real_phase = -minus_two_pi_over_c * (l * u + m * v + n * w)
+            # For each source
+            for source in range(lm.shape[0]):
+                l, m = lm[source]
+                n = np.sqrt(1.0 - l**2 - m**2) - 1.0
 
-            # Multiple in frequency for each channel
-            for chan in range(frequency.shape[0]):
-                p = real_phase * frequency[chan]
+                # e^(-2*pi*(l*u + m*v + n*w)/c)
+                real_phase = minus_two_pi_over_c * (l * u + m * v + n * w)
 
-                im_of_vis[source,
-                          chan] += (np.cos(p) * vis[row, chan].real -
-                                    np.sin(p) * vis[row, chan].imag)
-                # Note for the adjoint we don't need the imaginary part
-                # and we can elide the call to exp
+                # Multiple in frequency for each channel
+                for chan in range(frequency.shape[0]):
+                    p = real_phase * frequency[chan] * 1.0j
 
-    return im_of_vis
+                    # Our phase input is purely imaginary
+                    # so we can can elide a call to exp
+                    # and just compute the cos and sin
+                    # @simon does this really make a difference?
+                    # I thought a complex exponential is evaluated
+                    # as a sum of sin and cos anyway
+                    vis_of_im[row, chan] += np.exp(p)*image[source, chan]
+
+        return vis_of_im
+
+    return _im_to_vis_impl
 
 
-def im_to_vis(image, uvw, lm, frequency, dtype=None):
-    vis_of_im = np.zeros((uvw.shape[0], frequency.shape[0]),
-                         dtype=np.complex128 if dtype is None else dtype)
-
-    return _im_to_vis_impl(image, uvw, lm, frequency, vis_of_im)
-
-
+@generated_jit(nopython=True, nogil=True, cache=True)
 def vis_to_im(vis, uvw, lm, frequency, dtype=None):
-    im_of_vis = np.zeros((lm.shape[0], frequency.shape[0]),
-                         dtype=np.float64 if dtype is None else dtype)
+    # Infer output dtype if none provided
+    if is_numba_type_none(dtype):
+        # Support both real and complex visibilities...
+        if isinstance(vis.dtype, numba.types.scalars.Complex):
+            vis_comp_dtype = np.dtype(vis.dtype.underlying_float.name)
+        else:
+            vis_comp_dtype = np.dtype(vis.dtype.name)
 
-    return _vis_to_im_impl(vis, uvw, lm, frequency, im_of_vis)
+        out_dtype = np.result_type(vis_comp_dtype,
+                                   *(np.dtype(a.dtype.name) for a in
+                                     (uvw, lm, frequency)))
+    else:
+        if isinstance(dtype, numba.types.scalars.Complex):
+            raise TypeError("dtype must be complex")
+
+        out_dtype = dtype.dtype
+
+    def _vis_to_im_impl(vis, uvw, lm, frequency, dtype=None):
+        im_of_vis = np.zeros((lm.shape[0], frequency.shape[0]),
+                             dtype=out_dtype)
+
+        # For each source
+        for source in range(lm.shape[0]):
+            l, m = lm[source]
+            n = np.sqrt(1.0 - l ** 2 - m ** 2) - 1.0
+            # For each uvw coordinate
+            for row in range(uvw.shape[0]):
+                u, v, w = uvw[row]
+
+                # e^(-2*pi*(l*u + m*v + n*w)/c)
+                real_phase = -minus_two_pi_over_c * (l * u + m * v + n * w)
+
+                # Multiple in frequency for each channel
+                for chan in range(frequency.shape[0]):
+                    p = real_phase * frequency[chan]
+
+                    im_of_vis[source,
+                              chan] += (np.cos(p) * vis[row, chan].real -
+                                        np.sin(p) * vis[row, chan].imag)
+                    # Note for the adjoint we don't need the imaginary part
+                    # and we can elide the call to exp
+
+        return im_of_vis
+
+    return _vis_to_im_impl
 
 
 _DFT_DOCSTRING = namedtuple(


### PR DESCRIPTION
This will allow them to be embedded in other numba jitted code.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
