### PR TITLE
DFT docstring fixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.5 (YYYY-MM-DD)
 ------------------
+* Directly jit DFT functions (:pr:`100`, :pr:`101`)
 * Spectral Models (:pr:`86`)
 * Fix radec sign conversion in wsclean sky model (:pr:`96`)
 * Full Time and Channel Averaging Implementation (:pr:`80`, :pr:`97`, :pr:`98`)

--- a/africanus/dft/kernels.py
+++ b/africanus/dft/kernels.py
@@ -136,8 +136,9 @@ im_to_vis_docs = _DFT_DOCSTRING(
     frequency : :class:`numpy.ndarray`
         frequencies of shape :code:`(chan,)`
     dtype : np.dtype, optional
-        Datatype of result. Should be either np.complex64
-        or np.complex128. Defaults to np.complex128
+        Datatype of result. Should be either np.complex64 or np.complex128.
+        If ``None``, :func:`numpy.result_type` is used to infer the data type
+        from the inputs.
     """,
 
     returns="""
@@ -178,8 +179,9 @@ vis_to_im_docs = _DFT_DOCSTRING(
     frequency : :class:`numpy.ndarray`
         frequencies of shape :code:`(chan,)`
     dtype : np.dtype, optional
-        Datatype of result. Should be either np.float32
-        or np.float64. Defaults to np.float64
+        Datatype of result. Should be either np.float32 or np.float64.
+        If ``None``, :func:`numpy.result_type` is used to infer the data type
+        from the inputs.
     """,
 
     returns="""


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
