### PR TITLE
Fix WEIGHT_SPECTRUM averaging and expand averaging test suite

### DIFF
--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -270,6 +270,7 @@ def test_averager(time, ant1, ant2, flagged_rows,
     expected_times = [time[i].mean(axis=0) for i in nom_idx]
     expected_ant1 = [ant1[i[0]] for i in nom_idx]
     expected_ant2 = [ant2[i[0]] for i in nom_idx]
+    expected_flag_row = [flag_row[i].any(axis=0) for i in eff_idx]
 
     # Take mean average, but sum of interval and exposure
     expected_uvw = [uvw[i].mean(axis=0) for i in eff_idx]
@@ -280,6 +281,7 @@ def test_averager(time, ant1, ant2, flagged_rows,
 
     assert_array_equal(row_meta.time, expected_times)
     assert_array_equal(row_meta.interval, expected_interval)
+    assert_array_equal(row_meta.flag_row, expected_flag_row)
     assert_array_equal(avg.antenna1, expected_ant1)
     assert_array_equal(avg.antenna2, expected_ant2)
     assert_array_equal(avg.time_centroid, expected_time_centroids)

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -397,4 +397,6 @@ def test_dask_averager(time, ant1, ant2, flagged_rows,
                    time_bin_secs=time_bin_secs,
                    chan_bin_size=chan_bin_size)
 
-    avg.vis.compute()
+    # Compute all the fields
+    fields = [getattr(avg, f) for f in avg._fields]
+    avg = type(avg)(*da.compute(fields)[0])


### PR DESCRIPTION
* Flagged weight spectrum bins were not assigned into the final weight spectrum return array.
* Add tests for flag_row, visibility, flag, sigma spectrum and weight spectrum averaging.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
