### PR TITLE
Setup fixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.8 (YYYY-MM-DD)
 ------------------
 
+* Fix testing extras_require (:pr:`107`)
 * Fix WEIGHT_SPECTRUM averaging and add more averaging tests (:pr:`106`)
 
 0.1.7 (2019-05-09)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-from .africanus.compatibility import PY2
+PY2 = sys.version_info[0] == 2
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-PY2 = sys.version_info[0] == 2
+from .africanus.compatibility import PY2
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ _all_extras = extras_require.values()
 extras_require['complete'] = sorted(set(sum(_non_cuda_extras, [])))
 extras_require['complete-cuda'] = sorted(set(sum(_all_extras, [])))
 
-setup_requirements = ['pytest-runner', ]
-test_requirements = (['pytest'] +
+setup_requirements = []
+test_requirements = (extras_require['pytest'] +
                      extras_require['astropy'] +
                      extras_require['python-casacore'] +
                      extras_require['dask'] +

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['complete'] = sorted(set(sum(_non_cuda_extras, [])))
 extras_require['complete-cuda'] = sorted(set(sum(_all_extras, [])))
 
 setup_requirements = []
-test_requirements = (extras_require['pytest'] +
+test_requirements = (extras_require['testing'] +
                      extras_require['astropy'] +
                      extras_require['python-casacore'] +
                      extras_require['dask'] +


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
