### PR TITLE
Use environment markers in setup.py

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.8 (YYYY-MM-DD)
 ------------------
 
+* Use environment markers in setup.py (:pr:`110`)
 * Add `apply_gains`, a wrapper around `predict_vis` (:pr:`108`)
 * Fix testing extras_require (:pr:`107`)
 * Fix WEIGHT_SPECTRUM averaging and add more averaging tests (:pr:`106`)

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,7 @@
 """The setup script."""
 
 import os
-import sys
 from setuptools import setup, find_packages
-
-PY2 = sys.version_info[0] == 2
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -35,7 +32,8 @@ extras_require = {
     'dask': ['dask[array] >= 1.1.0'],
     'jax': ['jax == 0.1.27', 'jaxlib == 0.1.14'],
     'scipy': ['scipy >= 1.0.0'],
-    'astropy': ['astropy >= 2.0.0, < 3.0.0' if PY2 else 'astropy >= 3.0.0'],
+    'astropy': ['astropy >= 2.0.0, < 3.0; python_version <= "2.7"',
+                'astropy >= 3.0; python_version >= "3.0"'],
     'python-casacore': ['python-casacore >= 2.2.1'],
     'testing': ['pytest', 'pytest-runner']
 }


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
