### PR TITLE
Upgrade DFT kernels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
+* Added corelation axis and flags to DFT kernels (:pr:`118`)
 * Removed `apply_gains`. Use `africanus.calibration.utils.correct_vis`
   instead (:pr:`118`)
 * Add streams parameter to dask `predict_vis` (:pr:`118`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
+* Upgraded DFT kernels to have a correlation axis and added flags
+  for vis_to_im. Added predict_from_fits example. (:pr:`122`)
 * Fixed segfault when using `_unique_internal` on empty ndarrays (:pr:`123`)
 * Removed `apply_gains`. Use `africanus.calibration.utils.correct_vis`
   instead (:pr:`118`)

--- a/africanus/calibration/tests/test_phase_only.py
+++ b/africanus/calibration/tests/test_phase_only.py
@@ -56,7 +56,8 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     # simulate model data (pure Stokes I)
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
-        this_flux = np.tile(flux[dir], (n_chan, n_cor)).reshape(1, n_chan, n_cor)
+        this_flux = np.tile(flux[dir], (n_chan,
+                            n_cor)).reshape(1, n_chan, n_cor)
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
         model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()

--- a/africanus/calibration/tests/test_phase_only.py
+++ b/africanus/calibration/tests/test_phase_only.py
@@ -57,7 +57,7 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
         this_flux = np.tile(flux[dir], (n_chan,
-                            n_cor)).reshape(1, n_chan, n_cor)
+                                        n_cor)).reshape(1, n_chan, n_cor)
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
         model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()

--- a/africanus/calibration/tests/test_phase_only.py
+++ b/africanus/calibration/tests/test_phase_only.py
@@ -56,8 +56,7 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     # simulate model data (pure Stokes I)
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
-        this_flux = np.tile(flux[dir], (n_chan,
-                                        n_cor)).reshape(1, n_chan, n_cor)
+        this_flux = np.tile(flux[dir], (n_chan, n_cor))[None, :, :]
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
         model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()

--- a/africanus/calibration/tests/test_phase_only.py
+++ b/africanus/calibration/tests/test_phase_only.py
@@ -56,10 +56,9 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     # simulate model data (pure Stokes I)
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
-        this_flux = np.tile(flux[dir], (n_chan)).reshape(1, n_chan)
+        this_flux = np.tile(flux[dir], (n_chan, n_cor)).reshape(1, n_chan, n_cor)
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
-        model_data[:, :, dir, 0] = model_tmp
-        model_data[:, :, dir, 1] = model_tmp
+        model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()
     # simulate gains (just radnomly scattered around 1 for now)
     jones = np.ones((n_time, n_ant, n_chan, n_dir, n_cor), dtype=np.complex64)

--- a/africanus/calibration/tests/test_utils.py
+++ b/africanus/calibration/tests/test_utils.py
@@ -56,7 +56,8 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     # simulate model data (pure Stokes I)
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
-        this_flux = np.tile(flux[dir], (n_chan, n_cor)).reshape(1, n_chan, n_cor)
+        this_flux = np.tile(flux[dir], (n_chan,
+                            n_cor)).reshape(1, n_chan, n_cor)
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
         model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()

--- a/africanus/calibration/tests/test_utils.py
+++ b/africanus/calibration/tests/test_utils.py
@@ -57,7 +57,7 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
         this_flux = np.tile(flux[dir], (n_chan,
-                            n_cor)).reshape(1, n_chan, n_cor)
+                                        n_cor)).reshape(1, n_chan, n_cor)
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
         model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()

--- a/africanus/calibration/tests/test_utils.py
+++ b/africanus/calibration/tests/test_utils.py
@@ -56,8 +56,7 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     # simulate model data (pure Stokes I)
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
-        this_flux = np.tile(flux[dir], (n_chan,
-                                        n_cor)).reshape(1, n_chan, n_cor)
+        this_flux = np.tile(flux[dir], (n_chan, n_cor))[None, :, :]
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
         model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()

--- a/africanus/calibration/tests/test_utils.py
+++ b/africanus/calibration/tests/test_utils.py
@@ -56,10 +56,9 @@ def make_dual_pol_data(sigma_n, n_dir, sigma_f):
     # simulate model data (pure Stokes I)
     for dir in range(n_dir):
         this_lm = lm[dir].reshape(1, 2)
-        this_flux = np.tile(flux[dir], (n_chan)).reshape(1, n_chan)
+        this_flux = np.tile(flux[dir], (n_chan, n_cor)).reshape(1, n_chan, n_cor)
         model_tmp = im_to_vis(this_flux, uvw, this_lm, freq)
-        model_data[:, :, dir, 0] = model_tmp
-        model_data[:, :, dir, 1] = model_tmp
+        model_data[:, :, dir, :] = model_tmp
     assert not np.isnan(model_data).any()
     # simulate gains (just radnomly scattered around 1 for now)
     jones = np.ones((n_time, n_ant, n_chan, n_dir, n_cor), dtype=np.complex64)

--- a/africanus/dft/dask.py
+++ b/africanus/dft/dask.py
@@ -43,7 +43,7 @@ def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
                          "match on first axis")
     if image.chunks[1] != frequency.chunks[0]:
         raise ValueError("Image chunks must match frequency "
-                         "frequency chunks on second axis")
+                         "chunks on second axis")
     return da.core.blockwise(_im_to_vis_wrapper, ("row", "chan", "corr"),
                              image, ("source", "chan", "corr"),
                              uvw, ("row", "(u,v,w)"),
@@ -69,7 +69,7 @@ def vis_to_im(vis, uvw, lm, frequency, flags, dtype=np.float64):
                          "match on first axis")
     if vis.chunks[1] != frequency.chunks[0]:
         raise ValueError("Vis chunks must match frequency "
-                         "frequency chunks on second axis")
+                         "chunks on second axis")
     if vis.chunks != flags.chunks:
         raise ValueError("Vis chunks must match flags "
                          "chunks on all axes")

--- a/africanus/dft/dask.py
+++ b/africanus/dft/dask.py
@@ -31,7 +31,7 @@ def _im_to_vis_wrapper(image, uvw, lm, frequency, dtype_):
 
 @requires_optional('dask.array', dask_import_error)
 def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
-    """ Dask wrapper for phase_delay function """
+    """ Dask wrapper for im_to_vis function """
     if lm.chunks[0][0] != lm.shape[0]:
         raise ValueError("lm chunks must match lm shape "
                          "on first axis")
@@ -41,8 +41,11 @@ def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
     if image.chunks[0][0] != lm.chunks[0][0]:
         raise ValueError("Image chunks and lm chunks must "
                          "match on first axis")
-    return da.core.blockwise(_im_to_vis_wrapper, ("row", "chan"),
-                             image, ("source", "chan"),
+    if image.chunks[1] != frequency.chunks[0]:
+        raise ValueError("Image chunks must match frequency "
+                         "frequency chunks on second axis")
+    return da.core.blockwise(_im_to_vis_wrapper, ("row", "chan", "corr"),
+                             image, ("source", "chan", "corr"),
                              uvw, ("row", "(u,v,w)"),
                              lm, ("source", "(l,m)"),
                              frequency, ("chan",),
@@ -51,20 +54,33 @@ def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
 
 
 @wraps(np_vis_to_im)
-def _vis_to_im_wrapper(vis, uvw, lm, frequency, dtype_):
-    return np_vis_to_im(vis, uvw[0], lm[0], frequency,
+def _vis_to_im_wrapper(vis, uvw, lm, frequency, flags, dtype_):
+    return np_vis_to_im(vis, uvw[0], lm[0],
+                        frequency, flags,
                         dtype=dtype_)[None, :]
 
 
 @requires_optional('dask.array', dask_import_error)
-def vis_to_im(vis, uvw, lm, frequency, dtype=np.float64):
-    """ Dask wrapper for phase_delay_adjoint function """
+def vis_to_im(vis, uvw, lm, frequency, flags, dtype=np.float64):
+    """ Dask wrapper for vis_to_im function """
 
-    ims = da.core.blockwise(_vis_to_im_wrapper, ("row", "source", "chan"),
-                            vis, ("row", "chan"),
+    if vis.chunks[0] != uvw.chunks[0]:
+        raise ValueError("Vis chunks and uvw chunks must "
+                         "match on first axis")
+    if vis.chunks[1] != frequency.chunks[0]:
+        raise ValueError("Vis chunks must match frequency "
+                         "frequency chunks on second axis")
+    if vis.chunks != flags.chunks:
+        raise ValueError("Vis chunks must match flags "
+                         "chunks on all axes")
+
+    ims = da.core.blockwise(_vis_to_im_wrapper,
+                            ("row", "source", "chan", "corr"),
+                            vis, ("row", "chan", "corr"),
                             uvw, ("row", "(u,v,w)"),
                             lm, ("source", "(l,m)"),
                             frequency, ("chan",),
+                            flags, ("row", "chan", "corr"),
                             adjust_chunks={"row": 1},
                             dtype=dtype,
                             dtype_=dtype)

--- a/africanus/dft/examples/predict_from_fits.py
+++ b/africanus/dft/examples/predict_from_fits.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+import argparse
+
+import numpy as np
+from astropy.io import fits
+from astropy import wcs
+import dask
+import dask.array as da
+from dask.diagnostics import ProgressBar
+from africanus.dft.dask import im_to_vis
+from africanus.model.coherency.dask import convert
+import xarray as xr
+from xarrayms import xds_from_ms, xds_from_table, xds_to_table
+
+
+def create_parser():
+    p = argparse.ArgumentParser()
+    p.add_argument("--ms", type=str)
+    p.add_argument("--fitsmodel", type=str)
+    p.add_argument("--row_chunks", default=10000, type=int)
+    p.add_argument("--ncpu", default=0, type=int)
+    p.add_argument("--colname", default="MODEL_DATA", type=str)
+    return p
+
+args = create_parser().parse_args()
+
+if args.ncpu:
+    ncpu = args.ncpu
+    import dask
+    from multiprocessing.pool import ThreadPool
+    dask.config.set(pool=ThreadPool(ncpu))
+else:
+    import multiprocessing
+    ncpu = multiprocessing.cpu_count()
+
+print("Using %i threads"%ncpu)
+
+# Get MS frequencies
+spw_ds = list(xds_from_table("::".join((args.ms, "SPECTRAL_WINDOW")),
+                             group_cols="__row__"))[0]
+
+# Get frequencies in the measurement set
+# If these do not match those in the fits
+# file we need to interpolate
+ms_freqs = spw_ds.CHAN_FREQ.data
+nchan = ms_freqs.compute().size
+
+# load in the fits file
+model = fits.getdata(args.fitsmodel)
+# get header
+hdr = fits.getheader(args.fitsmodel)
+
+# get image coordinates
+npix_l = hdr['NAXIS1']
+refpix_l = hdr['CRPIX1']
+delta_l = hdr['CDELT1'] * np.pi/180  # assumes untis are deg
+l_coord = np.arange(1 - refpix_l, 1 + npix_l - refpix_l)*delta_l
+
+npix_m = hdr['NAXIS2']
+refpix_m = hdr['CRPIX2']
+delta_m = hdr['CDELT2'] * np.pi/180  # assumes untis are deg
+m_coord = np.arange(1 - refpix_m, 1 + npix_m - refpix_m)*delta_m
+
+npix_tot = npix_l * npix_m
+
+# get frequencies
+nband = hdr['NAXIS4']
+refpix_nu = hdr['CRPIX3']
+delta_nu = hdr['CDELT4']  # assumes units are Hz
+ref_freq = np.float(hdr['CRVAL4'])
+freqs = ref_freq + np.arange(1 - refpix_nu, 1 + nband - refpix_nu) * delta_nu
+
+print("Reference frequency is ", ref_freq)
+
+# TODO - need to use convert for this
+ncorr = hdr['NAXIS3']
+if ncorr > 1:
+    print("You will have to convert Stokes to corr for DFT to work properly")
+
+# if frequencies do not match we fit a power law and interpolate/extrapolatye
+if ms_freqs.compute() != freqs:
+    print("Frequencies of fits cube do not match those of ms. "
+          "Interpolating/extrapoling using power law")
+    # print("Fits frequencies are ", freqs)
+    # print("Interpolating to ", ms_freqs.compute())
+    model_predict = np.zeros((nchan, ncorr, npix_l, npix_m), dtype=np.float64)
+    alphas = np.zeros((1, ncorr, npix_l, npix_m), dtype=np.float64)
+    I0s = np.zeros((1, ncorr, npix_l, npix_m), dtype=np.float64)
+    if nband > 1:
+        from africanus.model.spi.dask import fit_spi_components
+        weights_dask = da.ones(nband, chunks=nband)
+        freqs_dask = da.from_array(freqs, chunks=nband)
+        for corr in range(ncorr):
+            # only fit non-zero components
+            model_max = np.amax(np.abs(model[:, corr, :, :]), axis=0)
+            Idx = np.argwhere(model_max > 0)
+            Ix = Idx[:, 0]
+            Iy = Idx[:, 1]
+            fitcube = model[:, corr, Ix, Iy].T.astype(np.float64)
+            ncomps, _ = fitcube.shape
+            model_cube = da.from_array(fitcube, chunks=(ncomps//ncpu, nband))
+            
+            alpha, _, I0, _ = fit_spi_components(model_cube, weights_dask,
+                                                 freqs_dask, ref_freq)
+            
+            alphas[0, corr, Ix, Iy] = alpha
+            I0s[0, corr, Ix, Iy] = I0
+    else:
+        print("Single frequency fits file. "
+              "Assuming spectral index of -0.7 to extrapolate")
+        alphas = np.ones((1, ncorr, npix_l, npix_m), dtype=np.float64) * -0.7
+        I0s = model
+    
+    model_predict = I0s * (ms_freqs.reshape(nchan,
+                           1, 1, 1)/ref_freq) ** alphas
+else:
+    model_predict = model
+
+# set up coords for DFT
+ll, mm = np.meshgrid(l_coord, m_coord)
+lm = np.vstack((ll.flatten(), mm.flatten())).T
+lm = da.from_array(lm, chunks=(npix_tot, 2))
+# ms_freqs = da.from_array(ms_freqs, chunks=nchan)
+model_predict = np.transpose(model_predict.reshape(nchan, ncorr, npix_tot),
+                             [2, 0, 1])
+model_predict = da.from_array(model_predict, chunks=(npix_tot, nchan, ncorr))
+
+# do the predict
+writes = []
+for xds in xds_from_ms(args.ms,
+                           columns=["UVW", args.colname],
+                           chunks={"row": args.row_chunks}):
+    uvw = xds.UVW
+    vis = im_to_vis(model_predict, uvw, lm, ms_freqs)
+
+    data = getattr(xds, args.colname)
+    if data.shape != vis.shape:
+        print("Assuming only Stokes I passed in")
+        tmp_zero = da.zeros(vis.shape, chunks=(args.row_chunks, nchan, 1))
+        vis = da.concatenate((vis, tmp_zero, tmp_zero, vis), axis=-1)
+        vis = vis.rechunk((args.row_chunks, nchan, data.shape[-1]))       
+
+    # Assign visibilities to MODEL_DATA array on the dataset
+    model_data = xr.DataArray(vis, dims=["row", "chan", "corr"])
+    xds = xds.assign(MODEL_DATA=model_data)
+    # Create a write to the table
+    write = xds_to_table(xds, args.ms, [args.colname])
+    # Add to the list of writes
+    writes.append(write)
+
+# Submit all graph computations in parallel
+with ProgressBar():
+    dask.compute(writes)

--- a/africanus/dft/examples/predict_from_fits.py
+++ b/africanus/dft/examples/predict_from_fits.py
@@ -22,9 +22,10 @@ def create_parser():
     p = argparse.ArgumentParser()
     p.add_argument("--ms", type=str)
     p.add_argument("--fitsmodel", type=str)
-    p.add_argument("--row_chunks", default=10000, type=int)
+    p.add_argument("--row_chunks", default=4000, type=int)
     p.add_argument("--ncpu", default=0, type=int)
     p.add_argument("--colname", default="MODEL_DATA", type=str)
+    p.add_argument('--field', default=0, type=int)
     return p
 
 
@@ -47,48 +48,62 @@ spw_ds = list(xds_from_table("::".join((args.ms, "SPECTRAL_WINDOW")),
 # Get frequencies in the measurement set
 # If these do not match those in the fits
 # file we need to interpolate
-ms_freqs = spw_ds.CHAN_FREQ.data
-nchan = ms_freqs.compute().size
+ms_freqs = spw_ds.CHAN_FREQ.data.compute()
+nchan = ms_freqs.size
 
 # load in the fits file
 model = fits.getdata(args.fitsmodel)
 # get header
 hdr = fits.getheader(args.fitsmodel)
 
+# TODO - check that PHASE_DIR in MS matches that in fits
 # get image coordinates
+if hdr['CUNIT1'] != "DEG" and hdr['CUNIT1'] != "deg":
+    raise ValueError("Image units must be in degrees")
 npix_l = hdr['NAXIS1']
 refpix_l = hdr['CRPIX1']
 delta_l = hdr['CDELT1'] * np.pi/180  # assumes untis are deg
-l_coord = np.arange(1 - refpix_l, 1 + npix_l - refpix_l)*delta_l
+l0 = hdr['CRVAL1'] * np.pi/180
+l_coord = l0 + np.arange(1 - refpix_l, 1 + npix_l - refpix_l)*delta_l
 
+if hdr['CUNIT2'] != "DEG" and hdr['CUNIT2'] != "deg":
+    raise ValueError("Image units must be in degrees")
 npix_m = hdr['NAXIS2']
 refpix_m = hdr['CRPIX2']
 delta_m = hdr['CDELT2'] * np.pi/180  # assumes untis are deg
-m_coord = np.arange(1 - refpix_m, 1 + npix_m - refpix_m)*delta_m
+m0 = hdr['CRVAL2'] * np.pi/180
+m_coord = m0 + np.arange(1 - refpix_m, 1 + npix_m - refpix_m)*delta_m
 
 npix_tot = npix_l * npix_m
 
 # get frequencies
-nband = hdr['NAXIS4']
-refpix_nu = hdr['CRPIX3']
-delta_nu = hdr['CDELT4']  # assumes units are Hz
-ref_freq = np.float(hdr['CRVAL4'])
+if hdr["CTYPE4"] == 'FREQ':
+    nband = hdr['NAXIS4']
+    refpix_nu = hdr['CRPIX4']
+    delta_nu = hdr['CDELT4']  # assumes units are Hz
+    ref_freq = hdr['CRVAL4']
+    ncorr = hdr['NAXIS3']
+elif hdr["CTYPE3"] == 'FREQ':
+    nband = hdr['NAXIS3']
+    refpix_nu = hdr['CRPIX3']
+    delta_nu = hdr['CDELT3']  # assumes units are Hz
+    ref_freq = hdr['CRVAL3']
+    ncorr = hdr['NAXIS4']
+else:
+    raise ValueError("Freq axis must be 3rd or 4th")
+
 freqs = ref_freq + np.arange(1 - refpix_nu, 1 + nband - refpix_nu) * delta_nu
 
 print("Reference frequency is ", ref_freq)
 
 # TODO - need to use convert for this
-ncorr = hdr['NAXIS3']
 if ncorr > 1:
-    print("You will have to convert Stokes to corr for DFT to work properly")
+    raise ValueError("Currently only works on a single correlation")
 
 # if frequencies do not match we fit a power law and interpolate/extrapolatye
-if ms_freqs.compute() != freqs:
+if not (ms_freqs != freqs).all():
     print("Frequencies of fits cube do not match those of ms. "
           "Interpolating/extrapoling using power law")
-    # print("Fits frequencies are ", freqs)
-    # print("Interpolating to ", ms_freqs.compute())
-    model_predict = np.zeros((nchan, ncorr, npix_l, npix_m), dtype=np.float64)
     alphas = np.zeros((1, ncorr, npix_l, npix_m), dtype=np.float64)
     I0s = np.zeros((1, ncorr, npix_l, npix_m), dtype=np.float64)
     if nband > 1:
@@ -113,11 +128,10 @@ if ms_freqs.compute() != freqs:
     else:
         print("Single frequency fits file. "
               "Assuming spectral index of -0.7 to extrapolate")
-        alphas = np.ones((1, ncorr, npix_l, npix_m), dtype=np.float64) * -0.7
+        alphas = np.full((1, ncorr, npix_l, npix_m), -0.7, dtype=np.float64)
         I0s = model
 
-    model_predict = I0s * (ms_freqs.reshape(nchan,
-                                            1, 1, 1)/ref_freq) ** alphas
+    model_predict = I0s * (ms_freqs[:, None, None, None]/ref_freq) ** alphas
 else:
     model_predict = model
 
@@ -125,29 +139,34 @@ else:
 ll, mm = np.meshgrid(l_coord, m_coord)
 lm = np.vstack((ll.flatten(), mm.flatten())).T
 lm = da.from_array(lm, chunks=(npix_tot, 2))
-# ms_freqs = da.from_array(ms_freqs, chunks=nchan)
 model_predict = np.transpose(model_predict.reshape(nchan, ncorr, npix_tot),
                              [2, 0, 1])
 model_predict = da.from_array(model_predict, chunks=(npix_tot, nchan, ncorr))
+ms_freqs = spw_ds.CHAN_FREQ.data
 
 # do the predict
 writes = []
 for xds in xds_from_ms(args.ms,
                        columns=["UVW", args.colname],
                        chunks={"row": args.row_chunks}):
-    uvw = xds.UVW
+    uvw = xds.UVW.data
     vis = im_to_vis(model_predict, uvw, lm, ms_freqs)
 
     data = getattr(xds, args.colname)
     if data.shape != vis.shape:
         print("Assuming only Stokes I passed in")
-        tmp_zero = da.zeros(vis.shape, chunks=(args.row_chunks, nchan, 1))
-        vis = da.concatenate((vis, tmp_zero, tmp_zero, vis), axis=-1)
+        if vis.shape[-1] == 1 and data.shape[-1] == 4:
+            tmp_zero = da.zeros(vis.shape, chunks=(args.row_chunks, nchan, 1))
+            vis = da.concatenate((vis, tmp_zero, tmp_zero, vis), axis=-1)
+        elif vis.shape[-1] == 1 and data.shape[-1] == 2:
+            vis = da.concatenate((vis, vis), axis=-1)
+        else:
+            raise ValueError("Incompatible corr axes")
         vis = vis.rechunk((args.row_chunks, nchan, data.shape[-1]))
 
     # Assign visibilities to MODEL_DATA array on the dataset
     model_data = xr.DataArray(vis, dims=["row", "chan", "corr"])
-    xds = xds.assign(MODEL_DATA=model_data)
+    xds = xds.assign(**{args.colname: model_data})
     # Create a write to the table
     write = xds_to_table(xds, args.ms, [args.colname])
     # Add to the list of writes

--- a/africanus/dft/kernels.py
+++ b/africanus/dft/kernels.py
@@ -102,13 +102,15 @@ def vis_to_im(vis, uvw, lm, frequency, flags, dtype=None):
 
                     # do not compute if any of the correlations
                     # are flagged (complicates uncertainties)
-                    if not np.any(flags[r, nu]):
-                        for c in range(ncorr):
-                            im_of_vis[s, nu, c] += (np.cos(p) *
-                                                    vis[r, nu, c].real -
-                                                    np.sin(p) *
-                                                    vis[r, nu, c].imag)
-                            # elide the call to exp since result is real
+                    if np.any(flags[r, nu]):
+                        continue
+
+                    for c in range(ncorr):
+                        # elide the call to exp since result is real
+                        im_of_vis[s, nu, c] += (np.cos(p) *
+                                                vis[r, nu, c].real -
+                                                np.sin(p) *
+                                                vis[r, nu, c].imag)
 
         return im_of_vis
 

--- a/africanus/dft/tests/test_dft.py
+++ b/africanus/dft/tests/test_dft.py
@@ -305,12 +305,7 @@ def test_symmetric_covariance():
     point_source = np.ones((1, nchan, ncorr), dtype=np.float64)
     for source in range(nsource):
         lm_i = lm[source].reshape(1, 2)
-        # Ki = np.zeros([nrows, 1], dtype=np.complex128)
         Ki = im_to_vis(point_source, uvw, lm_i, freq)
-        # for row in range(nrows):
-        #     Ki[row] = np.exp(1j*minus_two_pi_over_c*freq[0] *
-        #                      (uvw[row, 0]*l + uvw[row, 1]*m) +
-        #                      uvw[row, 2]*(n - 1))
         psf_source[:, source] = vis_to_im(Ki, uvw, lm, freq, flags).squeeze()
 
     assert_array_almost_equal(psf_source, psf_source.T, decimal=14)

--- a/africanus/dft/tests/test_dft.py
+++ b/africanus/dft/tests/test_dft.py
@@ -4,6 +4,7 @@
 """Tests for `codex-africanus` package."""
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 
 import pytest
 
@@ -23,212 +24,273 @@ def test_im_to_vis_phase_centre():
     lm = np.vstack((ll.flatten(), mm.flatten())).T
     nchan = 11
     frequency = np.linspace(1.0, 2.0, nchan, endpoint=True)
-
-    image = np.zeros([npix, npix, nchan], dtype=np.float64)
+    ncorr = 2
+    image = np.zeros((npix, npix, nchan, ncorr), dtype=np.float64)
     I0 = 1.0
     ref_freq = frequency[nchan//2]
     Inu = I0*(frequency/ref_freq)**(-0.7)
-    image[npix//2, npix//2, :] = Inu
-    image = image.reshape(npix**2, nchan)
+    for corr in range(ncorr):
+        image[npix//2, npix//2, :, corr] = Inu
+    image = image.reshape(npix**2, nchan, ncorr)
 
     vis = im_to_vis(image, uvw, lm, frequency)
 
-    for i in range(nchan):
-        tmp = vis[:, i] - Inu[i]
-        assert np.all(tmp.real < 1e-13)
-        assert np.all(tmp.imag < 1e-13)
+    for chan in range(nchan):
+        for corr in range(ncorr):
+            tmp = vis[:, chan, corr] - Inu[chan]
+            assert np.all(tmp.real < 1e-13)
+            assert np.all(tmp.imag < 1e-13)
 
 
-def test_im_to_vis_zero_w():
+def test_im_to_vis_simple():
     """
     This test checks that the result matches the analytic result
-    in the case when w = 0 for multiple channels and sources.
+    w = 0 for multiple channels and sources but a single correlation
     """
     from africanus.dft.kernels import im_to_vis
     from africanus.constants import minus_two_pi_over_c
     np.random.seed(123)
     nrow = 100
     uvw = np.random.random(size=(nrow, 3))
-    uvw[:, 2] = 0.0
     nchan = 3
     frequency = np.linspace(1.e9, 2.e9, nchan, endpoint=True)
     nsource = 5
     I0 = np.random.randn(nsource)
     ref_freq = frequency[nchan//2]
     image = I0[:, None] * (frequency/ref_freq)**(-0.7)
+    # add correlation axis
+    image = image[:, :, None]
     l = 0.001 + 0.1*np.random.random(nsource)  # noqa
     m = 0.001 + 0.1*np.random.random(nsource)
     lm = np.vstack((l, m)).T
-    vis = im_to_vis(image, uvw, lm, frequency)
+    vis = im_to_vis(image, uvw, lm, frequency).squeeze()
 
     vis_true = np.zeros([nrow, nchan], dtype=np.complex128)
 
     for ch in range(nchan):
         for source in range(nsource):
-            phase = (minus_two_pi_over_c*frequency[ch] * 1.0j *
-                     (uvw[:, 0]*lm[source, 0] +
-                      uvw[:, 1]*lm[source, 1]))
+            l, m = lm[source]
+            n = np.sqrt(1.0 - l**2 - m**2)
+            phase = minus_two_pi_over_c*frequency[ch] * 1.0j * \
+                (uvw[:, 0]*l + uvw[:, 1]*m + uvw[:, 2]*(n-1))
 
-            vis_true[:, ch] += image[source, ch]*np.exp(phase)
+            vis_true[:, ch] += image[source, ch, 0]*np.exp(phase)
+    assert_array_almost_equal(vis, vis_true, decimal=14)
 
-    assert np.allclose(vis, vis_true)
 
-
-def test_im_to_vis_single_baseline_and_chan():
+def test_im_to_vis_fft():
     """
-    Here we check that the result is consistent for
-    a single baseline, source and channel.
+    Test against the fft when uv on regular and w is zero.
     """
     from africanus.dft.kernels import im_to_vis
-    from africanus.constants import minus_two_pi_over_c
-    nrow = 1
-    uvw = np.random.random(size=(nrow, 3))
-    frequency = np.array([1.5e9])
-    l = 0.015  # noqa
-    m = -0.0123
-    lm = np.array([[l, m]])
-    n = np.sqrt(1 - l**2 - m**2)
-    image = np.array([[1.0]])
-    vis = im_to_vis(image, uvw, lm, frequency)
+    np.random.seed(123)
+    Fs = np.fft.fftshift
+    iFs = np.fft.ifftshift
 
-    vis_true = image*np.exp(minus_two_pi_over_c * frequency * 1.0j *
-                            (uvw[:, 0]*l + uvw[:, 1]*m + uvw[:, 2]*(n - 1.0)))
+    # set image and take fft
+    npix = 29
+    ncorr = 1
+    image = np.zeros((npix, npix, ncorr), dtype=np.float64)
+    fft_image = np.zeros((npix, npix, ncorr), dtype=np.complex128)
+    nsource = 25
+    for corr in range(ncorr):
+        Ix = np.random.randint(5, npix-5, nsource)
+        Iy = np.random.randint(5, npix-5, nsource)
+        image[Ix, Iy, corr] = np.random.randn(nsource)
+        fft_image[:, :, corr] = Fs(np.fft.fft2(iFs(image[:, :, corr])))
 
-    assert np.allclose(vis, vis_true)
-
-
-def test_vis_to_im():
-    """
-    Still thinking of a better test here but the simplest test
-    does exactly the same as the above.
-    If we have an auto-correlation we expect
-    to measure a flat image with value wsum
-    """
-    from africanus.dft.kernels import vis_to_im
-    nchan = 11
-
-    vis = np.ones([1, nchan], dtype=np.complex128)
-    uvw = np.zeros([1, 3], dtype=np.float64)
-    npix = 5
-    x = np.linspace(-0.1, 0.1, npix)
-    ll, mm = np.meshgrid(x, x)
+    # image space coords
+    deltal = 0.001
+    # this assumes npix is odd
+    l_coord = np.arange(-(npix//2), npix//2+1) * deltal
+    ll, mm = np.meshgrid(l_coord, l_coord)
     lm = np.vstack((ll.flatten(), mm.flatten())).T
-    wsum = 1.0
+    # uv-space coords
+    u = Fs(np.fft.fftfreq(npix, d=deltal))
+    uu, vv = np.meshgrid(u, u)
+    uvw = np.zeros((npix**2, 3), dtype=np.float64)
+    uvw[:, 0] = uu.flatten()
+    uvw[:, 1] = vv.flatten()
+    nchan = 1
+    image = image.reshape(npix**2, nchan, ncorr)
+    frequency = np.ones(nchan, dtype=np.float64)
+    from africanus.constants import c as lightspeed
+    frequency *= lightspeed  # makes result independent of frequency
 
-    frequency = np.linspace(1.0, 2.0, nchan, endpoint=True)
+    # take DFT and compare
+    vis = im_to_vis(image, uvw, lm, frequency)
+    fft_image = fft_image.reshape(npix**2, nchan, ncorr)
 
-    image = vis_to_im(vis, uvw, lm, frequency)
-
-    for i in range(nchan):
-        assert np.all(image[:, i] == wsum)
+    assert_array_almost_equal(vis, fft_image, decimal=13)
 
 
 def test_adjointness():
     """
-    She is the mother of all tests.
-    The DFT should be perfectly self adjoint up to machine precision.
+    The above tests only test im_to_vis but since vis_to_im
+    is simply the adjoint (up to machine precision) that is
+    all we need to test.
     """
     from africanus.dft.kernels import im_to_vis as R
     from africanus.dft.kernels import vis_to_im as RH
+    from africanus.constants import c as lightspeed
 
     np.random.seed(123)
-    Npix = 33
-    Nvis = 1000
-    Nchan = 1
+    nsource = 21
+    nrow = 31
+    nchan = 3
+    ncorr = 4
 
-    uvw = np.random.random(size=(Nvis, 3))
-    x = np.linspace(-0.1, 0.1, Npix)
-    ll, mm = np.meshgrid(x, x)
-    lm = np.vstack((ll.flatten(), mm.flatten())).T
-    frequency = np.array([1.0])
+    uvw = 100 * np.random.random(size=(nrow, 3))
+    ll = 0.01*np.random.randn(nsource)
+    mm = 0.01*np.random.randn(nsource)
+    lm = np.vstack((ll, mm)).T
+    frequency = np.arange(1, nchan+1) * lightspeed  # avoid overflow
 
-    gamma1 = np.random.randn(Npix**2, Nchan)
-    gamma2 = np.random.randn(Nvis, Nchan)
+    shape_im = (nsource, nchan, ncorr)
+    size_im = np.prod(shape_im)
+    gamma_im = np.random.randn(nsource, nchan, ncorr)
+    shape_vis = (nrow, nchan, ncorr)
+    size_vis = np.prod(shape_vis)
+    gamma_vis = np.random.randn(nrow, nchan, ncorr)
+    flag = np.zeros(shape_vis, dtype=bool)
 
-    LHS = (gamma2.T.dot(R(gamma1, uvw, lm, frequency))).real
-    RHS = (RH(gamma2, uvw, lm, frequency).T.dot(gamma1)).real
-    assert np.all(np.abs(LHS - RHS) < 1e-11)
+    LHS = (gamma_vis.reshape(size_vis, 1).T.dot(
+        R(gamma_im, uvw, lm, frequency).reshape(size_vis, 1))).real
+    RHS = (RH(gamma_vis, uvw, lm, frequency, flag).reshape(
+        size_im, 1).T.dot(gamma_im.reshape(size_im, 1))).real
+
+    assert np.abs(LHS - RHS) < 1e-14
+
+
+def test_vis_to_im_flagged():
+    """
+    The above doesn't apply any flags so we need to test that
+    separately. Note that weights for flagged data need to be
+    set to zero for operators to be self adjoint.
+    """
+    from africanus.dft.kernels import vis_to_im
+    from africanus.constants import c as lightspeed
+
+    np.random.seed(123)
+    nsource = 21
+    nrow = 31
+    nchan = 3
+    ncorr = 4
+
+    uvw = 100 * np.random.random(size=(nrow, 3))
+    uvw[0, :] = 0.0
+    ll = 0.01*np.random.randn(nsource)
+    mm = 0.01*np.random.randn(nsource)
+    lm = np.vstack((ll, mm)).T
+    frequency = np.arange(1, nchan+1) * lightspeed  # avoid overflow
+
+    vis = np.random.randn(nrow, nchan, ncorr) + \
+        1.0j*np.random.randn(nrow, nchan, ncorr)
+    vis[0, :, :] = 1.0
+
+    flags = np.ones((nrow, nchan, ncorr), dtype=bool)
+    flags[0, :, :] = 0
+
+    frequency = np.ones(nchan, dtype=np.float64) * lightspeed
+    im_of_vis = vis_to_im(vis, uvw, lm, frequency, flags)
+
+    assert_array_almost_equal(im_of_vis,
+                              np.ones((nsource, nchan, ncorr),
+                                      dtype=np.float64),
+                              decimal=13)
 
 
 def test_im_to_vis_dask():
+    """
+    Tests against numpy version
+    """
     da = pytest.importorskip("dask.array")
     from africanus.dft.kernels import im_to_vis as np_im_to_vis
     from africanus.dft.dask import im_to_vis as dask_im_to_vis
+    from africanus.constants import c as lightspeed
 
-    nrow = 100
-    uvw = np.random.random(size=(nrow, 3))
-    npix = 35  # must be odd for this test to work
-    x = np.linspace(-0.1, 0.1, npix)
-    ll, mm = np.meshgrid(x, x)
-    lm = np.vstack((ll.flatten(), mm.flatten())).T
+    nrow = 8000
+    uvw = 100 * np.random.random(size=(nrow, 3))
+    nsource = 800  # must be odd for this test to work
+    ll = 0.01*np.random.randn(nsource)
+    mm = 0.01*np.random.randn(nsource)
+    lm = np.vstack((ll, mm)).T
     nchan = 11
-    frequency = np.linspace(1.0, 2.0, nchan, endpoint=True)
-
-    image = np.zeros([npix, npix, nchan], dtype=np.float64)
-    I0 = 1.0
-    ref_freq = frequency[nchan//2]
-    Inu = I0*(frequency/ref_freq)**(-0.7)
-    image[npix//2, npix//2, :] = Inu
-    image = image.reshape(npix**2, nchan)
+    frequency = np.linspace(1.0, 2.0, nchan) * lightspeed
+    ncorr = 4
+    image = np.random.randn(nsource, nchan, ncorr)
 
     # set up dask arrays
-    uvw_dask = da.from_array(uvw, chunks=(25, 3))
-    lm_dask = da.from_array(lm, chunks=(npix**2, 2))
-    frequency_dask = da.from_array(frequency, chunks=4)
-    image_dask = da.from_array(image, chunks=(npix**2, 4))
+    uvw_dask = da.from_array(uvw, chunks=(nrow//8, 3))
+    lm_dask = da.from_array(lm, chunks=(nsource, 2))
+    frequency_dask = da.from_array(frequency, chunks=nchan//2)
+    image_dask = da.from_array(image, chunks=(nsource, nchan//2, ncorr))
 
     vis = np_im_to_vis(image, uvw, lm, frequency)
     vis_dask = dask_im_to_vis(image_dask, uvw_dask,
                               lm_dask, frequency_dask).compute()
 
-    assert np.allclose(vis, vis_dask)
+    assert_array_almost_equal(vis, vis_dask, decimal=13)
 
 
 def test_vis_to_im_dask():
+    """
+    Tests against numpy version
+    """
     da = pytest.importorskip("dask.array")
     from africanus.dft.kernels import vis_to_im as np_vis_to_im
     from africanus.dft.dask import vis_to_im as dask_vis_to_im
+    from africanus.constants import c as lightspeed
 
     nchan = 11
+    nrow = 8000
+    nsource = 80
+    ncorr = 4
 
-    vis = np.ones([100, nchan], dtype=np.complex128)
-    uvw = np.zeros([100, 3], dtype=np.float64)
-    npix = 5
-    x = np.linspace(-0.1, 0.1, npix)
-    ll, mm = np.meshgrid(x, x)
-    lm = np.vstack((ll.flatten(), mm.flatten())).T
+    vis = np.random.randn(nrow, nchan, ncorr)
+    uvw = np.random.randn(nrow, 3)
 
-    frequency = np.linspace(1.0, 2.0, nchan, endpoint=True)
+    ll = 0.01*np.random.randn(nsource)
+    mm = 0.01*np.random.randn(nsource)
+    lm = np.vstack((ll, mm)).T
+    nchan = 11
+    frequency = np.linspace(1.0, 2.0, nchan) * lightspeed
 
-    image = np_vis_to_im(vis, uvw, lm, frequency)
+    flagged_frac = 0.45
+    flags = np.random.choice(a=[False, True], size=(nrow, nchan, ncorr),
+                             p=[flagged_frac, 1-flagged_frac])
+
+    image = np_vis_to_im(vis, uvw, lm, frequency, flags)
 
     # set up dask arrays
-    uvw_dask = da.from_array(uvw, chunks=(25, 3))
-    lm_dask = da.from_array(lm, chunks=(5, 2))
-    frequency_dask = da.from_array(frequency, chunks=4)
-    vis_dask = da.from_array(vis, chunks=(25, 4))
+    uvw_dask = da.from_array(uvw, chunks=(nrow//8, 3))
+    lm_dask = da.from_array(lm, chunks=(nsource, 2))
+    frequency_dask = da.from_array(frequency, chunks=nchan//2)
+    vis_dask = da.from_array(vis, chunks=(nrow//8, nchan//2, ncorr))
+    flags_dask = da.from_array(flags, chunks=(nrow//8, nchan//2, ncorr))
 
     image_dask = dask_vis_to_im(
-        vis_dask, uvw_dask, lm_dask, frequency_dask).compute()
+        vis_dask, uvw_dask, lm_dask, frequency_dask, flags_dask).compute()
 
-    assert np.allclose(image, image_dask)
+    assert_array_almost_equal(image, image_dask, decimal=13)
 
 
 def test_symmetric_covariance():
     """
-    Test that the image plane covariance matrix R^H Sigma^-1R is Hermitian
+    Test that the image plane precision matrix R^H Sigma^-1R is Hermitian
     (symmetric since its real).
     """
-    from africanus.dft.kernels import vis_to_im
-    from africanus.constants.consts import minus_two_pi_over_c
+    from africanus.dft.kernels import vis_to_im, im_to_vis
     np.random.seed(123)
 
-    lmmax = 0.05
     nsource = 25
+    ncorr = 1
+    nchan = 1
 
-    l = -0.8*lmmax + 1.6*lmmax*np.random.random(nsource)  # noqa
-    m = -0.8 * lmmax + 1.6 * lmmax * np.random.random(nsource)
-    lm = np.vstack((l, m)).T
+    lmmax = 0.05
+    ll = -lmmax + 2*lmmax*np.random.random(nsource)  # noqa
+    mm = -lmmax + 2*lmmax*np.random.random(nsource)
+    lm = np.vstack((ll, mm)).T
 
     nrows = 1000
     uvw = np.random.randn(nrows, 3) * 1000
@@ -236,16 +298,19 @@ def test_symmetric_covariance():
 
     freq = np.array([1.0e9])
 
+    flags = np.zeros((nrows, nchan, ncorr), dtype=np.bool)
+
     # get the "psf" matrix at source locations
     psf_source = np.zeros((nsource, nsource), dtype=np.float64)
+    point_source = np.ones((1, nchan, ncorr), dtype=np.float64)
     for source in range(nsource):
-        l, m = lm[source]
-        n = np.sqrt(1 - l ** 2 - m ** 2)
-        Ki = np.zeros([nrows, 1], dtype=np.complex128)
-        for row in range(nrows):
-            Ki[row] = np.exp(1j*minus_two_pi_over_c*freq[0] *
-                             (uvw[row, 0]*l + uvw[row, 1]*m) +
-                             uvw[row, 2]*(n - 1))
-        psf_source[:, source:source+1] = vis_to_im(Ki, uvw, lm, freq)
+        lm_i = lm[source].reshape(1, 2)
+        # Ki = np.zeros([nrows, 1], dtype=np.complex128)
+        Ki = im_to_vis(point_source, uvw, lm_i, freq)
+        # for row in range(nrows):
+        #     Ki[row] = np.exp(1j*minus_two_pi_over_c*freq[0] *
+        #                      (uvw[row, 0]*l + uvw[row, 1]*m) +
+        #                      uvw[row, 2]*(n - 1))
+        psf_source[:, source] = vis_to_im(Ki, uvw, lm, freq, flags).squeeze()
 
-    assert np.allclose(psf_source, psf_source.T, atol=1e-12, rtol=1e-10)
+    assert_array_almost_equal(psf_source, psf_source.T, decimal=14)

--- a/africanus/gps/kernels.py
+++ b/africanus/gps/kernels.py
@@ -8,7 +8,7 @@ import numpy as np
 from africanus.gps.utils import abs_diff
 
 
-def exponential_squared(x, xp, sigmaf, l):
+def exponential_squared(x, xp, sigmaf, l, pspec=False):
     """
     Create exponential squared covariance
     function between :math:`D` dimensional
@@ -33,5 +33,18 @@ def exponential_squared(x, xp, sigmaf, l):
     K : :class:`numpy.ndarray`
         Array of shape :code:`(N, Np)`
     """
-    xxp = abs_diff(x, xp)
-    return sigmaf**2*np.exp(-xxp**2/(2*l**2))
+    if pspec:
+        N, D = x.shape
+        if D != 1:
+            raise(NotImplementedError, "Only 1D pspecs supported")
+        if (x != xp).any():
+            raise(ValueError, "pspec only defined if x = xp")
+        x = x.squeeze()
+        delx = x[1] - x[0]
+        if (x[1::] - x[0:-1] != delx).any():
+            raise(ValueError, "pspec only defined on regular grid")
+        s = np.fft.fftshift(np.fft.fftfreq(N, d=delx))
+        return np.sqrt(2*np.pi*l)*sigmaf**2.0*np.exp(-l**2*s**2/2.0)
+    else:
+        xxp = abs_diff(x, xp)
+        return sigmaf**2*np.exp(-xxp**2/(2*l**2))

--- a/africanus/model/spi/__init__.py
+++ b/africanus/model/spi/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from .component_spi import fit_spi_components
+from africanus.model.spi.component_spi import fit_spi_components

--- a/africanus/model/spi/component_spi.py
+++ b/africanus/model/spi/component_spi.py
@@ -67,7 +67,9 @@ def fit_spi_components(data, weights, freqs, freq0,
     if I0i is not None:
         out[2, :] = I0i
     else:
-        out[2, :] = np.ones(ncomps, dtype=dtype)
+        tmp = np.abs(freqs - freq0)
+        ref_freq_idx = np.argwhere(tmp == tmp.min()).squeeze()
+        out[2, :] = data[:, ref_freq_idx]
     return _fit_spi_components_impl(data, weights, freqs, freq0, out,
                                     jac, ncomps, nfreqs, tol, maxiter)
 

--- a/africanus/rime/dask_predict.py
+++ b/africanus/rime/dask_predict.py
@@ -81,6 +81,7 @@ class CoherencyStreamReduction(Mapping):
     Produces graph serially summing coherencies in
     ``stream`` parallel streams.
     """
+
     def __init__(self, time_index, antenna1, antenna2,
                  dde1_jones, source_coh, dde2_jones,
                  out_name, streams):

--- a/docs/dft-api.rst
+++ b/docs/dft-api.rst
@@ -4,21 +4,24 @@ Direct Fourier Transform
 
 Functions used to compute the discretised
 direct Fourier transform (DFT)
-for an ideal unpolarised interferometer.
+for an ideal interferometer.
 The DFT for an ideal interferometer is
 defined as
 
 .. math::
 
-    V(u,v,w) = \int I(l,m) e^{-2\pi i
+    V(u,v,w) = \int B(l,m) e^{-2\pi i
         \left( ul + vm + w(n-1)\right)}
         \frac{dl dm}{n}
 
-where :math:`u,v,w` are data (visibility :math:`V`) space
-coordinates and :math:`l,m,n` are signal (image :math:`I`)
-space coordinates. We adopt the convention where we
-absorb the fixed coordinate :math:`n` in the denominator
-into the image.
+where :math:`u,v,w` are data space coordinates and
+where visibilities :math:`V` have been obtained.
+The :math:`l,m,n` are signal space coordinates at which
+we wish to reconstruct the signal :math:`B`. Note that
+the signal correspondes to the brightness matrix
+and not the Stokes parameters. We adopt the convention
+where we absorb the fixed coordinate :math:`n` in the
+denominator into the image.
 Note that the data space coordinates have an implicit
 dependence on frequency and time and that the image
 has an implicit dependence on frequency.
@@ -27,7 +30,7 @@ The discretised form of the DFT can be written as
 .. math::
 
     V(u,v,w) = \sum_s e^{-2 \pi i
-        (u l_s + v m_s + w (n_s - 1))} \cdot I_s
+        (u l_s + v m_s + w (n_s - 1))} \cdot B_s
 
 where :math:`s` labels the source (or pixel) location.
 This can be cast into a matrix equation as follows

--- a/docs/dft-api.rst
+++ b/docs/dft-api.rst
@@ -33,7 +33,8 @@ The discretised form of the DFT can be written as
         (u l_s + v m_s + w (n_s - 1))} \cdot B_s
 
 where :math:`s` labels the source (or pixel) location.
-This can be cast into a matrix equation as follows
+If only a single correlation is present :math:`B = I`,
+this can be cast into a matrix equation as follows
 
 .. math::
 
@@ -42,7 +43,8 @@ This can be cast into a matrix equation as follows
 where :math:`R` is the operator that maps an
 image to visibility space. This mapping is
 implemented by the :func:`~africanus.dft.im_to_vis`
-function.
+function. If multiple correlations are present then
+each one is mapped to its corresponding visibility.
 An imaging algorithm also requires the adjoint
 denoted :math:`R^\dagger` which is simply the
 complex conjugate transpose of :math:`R`.


### PR DESCRIPTION
This adds the correlation axis to the dft kernels and flags for vis_to_im. I've also modified the tests and added a comparison to the FFT when w=0 and uv are on a regular grid. Let's see if I broke anything in the process. @sjperkins I see that even in master I get the following from flake8

africanus/rime/dask_predict.py:116:23: F841 local variable '_' is assigned to but never used
africanus/rime/dask_predict.py:208:23: F841 local variable '_' is assigned to but never used
africanus/rime/dask_predict.py:212:23: F841 local variable '_' is assigned to but never used
africanus/rime/dask_predict.py:303:30: F841 local variable '_' is assigned to but never used

