### PR TITLE
Testing and requirement updates

### DIFF
--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -1,13 +1,18 @@
 FROM kernsuite/base:3
+
+# Install base requirements
 RUN docker-apt-install python-pip
 RUN pip install --upgrade pip setuptools
 ADD . /code
+
 WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip install .[testing]
 RUN py.test -s -vvv /code/africanus
+
 # Test most functionality
-RUN docker-apt-install python-casacore
+# Install kern python-casacore to avoid build dependencies
+RUN apt install python-casacore
 RUN pip install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -1,4 +1,4 @@
-FROM kernsuite/base:3
+FROM kernsuite/base:5
 
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
@@ -15,5 +15,5 @@ RUN py.test -s -vvv /code/africanus
 # Test most functionality
 # Install kern python-casacore to avoid build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python-casacore
-RUN pip install .[astropy,dask,python-casacore,scipy,testing]
+RUN pip install .[astropy,dask,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -5,7 +5,7 @@ ADD . /code
 WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
-RUN pip install .
+RUN pip install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Test most functionality
 # RUN docker-apt-install python-casacore

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -1,7 +1,8 @@
 FROM kernsuite/base:3
 
 # Install base requirements
-RUN docker-apt-install python-pip
+RUN DEBIAN_FRONTEND=noninteractive apt update -y
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python-pip
 RUN pip install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
@@ -13,6 +14,6 @@ RUN py.test -s -vvv /code/africanus
 
 # Test most functionality
 # Install kern python-casacore to avoid build dependencies
-RUN apt install python-casacore
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python-casacore
 RUN pip install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -1,7 +1,13 @@
 FROM kernsuite/base:3
-RUN docker-apt-install python-pip python-casacore
+RUN docker-apt-install python-pip
 RUN pip install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
+# Test base install without optional installs works
+# Most of the tests will be skipped
+RUN pip install .
+RUN py.test -s -vvv /code/africanus
+# Test most functionality
+# RUN docker-apt-install python-casacore
 RUN pip install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -4,8 +4,8 @@ FROM kernsuite/base:3
 RUN docker-apt-install python-pip
 RUN pip install --upgrade pip setuptools
 ADD . /code
-
 WORKDIR /code
+
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip install .[testing]

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -8,6 +8,6 @@ WORKDIR /code
 RUN pip install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Test most functionality
-# RUN docker-apt-install python-casacore
+RUN docker-apt-install python-casacore
 RUN pip install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -1,4 +1,4 @@
-FROM kernsuite/base:3
+FROM kernsuite/base:5
 
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
@@ -15,5 +15,5 @@ RUN py.test -s -vvv /code/africanus
 # Test most functionality.
 # Install kern python-casacore to avoid build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-casacore
-RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
+RUN pip3 install .[astropy,dask,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -5,7 +5,7 @@ ADD . /code
 WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
-RUN pip3 install .
+RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Testing install
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -1,13 +1,18 @@
 FROM kernsuite/base:3
-RUN docker-apt-install python3-pip # python3-casacore
+
+# Install base requirements
+RUN docker-apt-install python3-pip
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
+
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
-# Testing install
+
+# Test most functionality.
+# Install kern python-casacore to avoid build dependencies
 RUN apt install python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -1,7 +1,8 @@
 FROM kernsuite/base:3
 
 # Install base requirements
-RUN docker-apt-install python3-pip
+RUN DEBIAN_FRONTEND=noninteractive apt update -y
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
@@ -13,6 +14,6 @@ RUN py.test -s -vvv /code/africanus
 
 # Test most functionality.
 # Install kern python-casacore to avoid build dependencies
-RUN apt install python3-casacore
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -8,5 +8,6 @@ WORKDIR /code
 RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Testing install
+RUN docker-apt-install python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -8,6 +8,6 @@ WORKDIR /code
 RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Testing install
-RUN docker-apt-install python3-casacore
+RUN apt install python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -1,10 +1,12 @@
-# python-casacore package removed due to
-# https://github.com/casacore/python-casacore/pull/132
-
 FROM kernsuite/base:3
 RUN docker-apt-install python3-pip # python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[astropy,dask,scipy,testing]
+# Test base install without optional installs works
+# Most of the tests will be skipped
+RUN pip3 install .
+RUN py.test -s -vvv /code/africanus
+# Testing install
+RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -1,14 +1,18 @@
 FROM kernsuite/base:dev
+
 # Install base requirements
 RUN docker-apt-install python3-pip
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
+
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
+
 # Test most functionality
+# Install kern python-casacore to avoid build dependencies
 RUN apt install python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -9,6 +9,6 @@ WORKDIR /code
 RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Test most functionality
-# RUN docker-apt-install python-casacore
+RUN docker-apt-install python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -1,4 +1,4 @@
-FROM kernsuite/base:dev
+FROM kernsuite/base:5
 
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
@@ -15,5 +15,5 @@ RUN py.test -s -vvv /code/africanus
 # Test most functionality
 # Install kern python-casacore to avoid build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-casacore
-RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
+RUN pip3 install .[astropy,dask,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -6,7 +6,7 @@ ADD . /code
 WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
-RUN pip3 install .
+RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Test most functionality
 # RUN docker-apt-install python-casacore

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -1,7 +1,8 @@
 FROM kernsuite/base:dev
 
 # Install base requirements
-RUN docker-apt-install python3-pip
+RUN DEBIAN_FRONTEND=noninteractive apt update -y
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
@@ -13,6 +14,6 @@ RUN py.test -s -vvv /code/africanus
 
 # Test most functionality
 # Install kern python-casacore to avoid build dependencies
-RUN apt install python3-casacore
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -9,6 +9,6 @@ WORKDIR /code
 RUN pip3 install .[testing]
 RUN py.test -s -vvv /code/africanus
 # Test most functionality
-RUN docker-apt-install python3-casacore
+RUN apt install python3-casacore
 RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -1,10 +1,14 @@
-# python-casacore package removed due to
-# https://github.com/casacore/python-casacore/pull/132
-
 FROM kernsuite/base:dev
-RUN docker-apt-install python3-pip # python3-casacore
+# Install base requirements
+RUN docker-apt-install python3-pip
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[astropy,dask,scipy,testing]
+# Test base install without optional installs works
+# Most of the tests will be skipped
+RUN pip3 install .
+RUN py.test -s -vvv /code/africanus
+# Test most functionality
+# RUN docker-apt-install python-casacore
+RUN pip3 install .[astropy,dask,python-casacore,scipy,testing]
 RUN py.test -s -vvv /code/africanus

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
+* Testing and requirement updates. (:pr:`124`)
 * Upgraded DFT kernels to have a correlation axis and added flags
   for vis_to_im. Added predict_from_fits example. (:pr:`122`)
 * Fixed segfault when using `_unique_internal` on empty ndarrays (:pr:`123`)

--- a/africanus/__init__.py
+++ b/africanus/__init__.py
@@ -6,6 +6,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+# NOTE(sjperkins)
+# Imports at this level within this module should be avoided,
+# or should fail gracefully as this is the base africanus module.
+# The setup.py file accesses the ``africanus.install`` modules
 import africanus.util.jax_init  # noqa
 
 __author__ = """Simon Perkins"""

--- a/africanus/compatibility.py
+++ b/africanus/compatibility.py
@@ -11,6 +11,47 @@ import sys
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
 
+# From 3.8, Collections Abstract Base Classes will be visible only
+# from collections.abc.
+try:
+    from collections.abc import (
+        Container,
+        Hashable,
+        Iterable,
+        Iterator,
+        Sized,
+        Callable,
+        Sequence,
+        MutableSequence,
+        Set,
+        MutableSet,
+        Mapping,
+        MutableMapping,
+        MappingView,
+        ItemsView,
+        KeysView,
+        ValuesView,
+    )
+except ImportError:
+    from collections import (
+        Container,
+        Hashable,
+        Iterable,
+        Iterator,
+        Sized,
+        Callable,
+        Sequence,
+        MutableSequence,
+        Set,
+        MutableSet,
+        Mapping,
+        MutableMapping,
+        MappingView,
+        ItemsView,
+        KeysView,
+        ValuesView,
+    )
+
 if PY3:
     import builtins
     range = range

--- a/africanus/install/__init__.py
+++ b/africanus/install/__init__.py
@@ -1,0 +1,4 @@
+# NOTE(sjperkins)
+# Imports at this level should be avoided,
+# or should fail gracefully as functionality
+# in these modules is called by setup.py

--- a/africanus/install/requirements.py
+++ b/africanus/install/requirements.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# NOTE(sjperkins)
+# Non standard library imports should be avoided,
+# or should fail gracefully as functionality
+# in these modules is called by setup.py
+import os
+
+# requirements
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+
+# Basic requirements containing no C extensions.
+# This is necessary for building on RTD
+requirements = ['appdirs >= 1.4.3',
+                'decorator']
+
+if not on_rtd:
+    requirements += [
+        # astropy breaks with numpy 1.15.3
+        # https://github.com/astropy/astropy/issues/7943
+        'numpy >= 1.14.0, != 1.15.3',
+        'numba >= 0.43.0']
+
+extras_require = {
+    'cuda': ['cupy >= 5.0.0', 'jinja2 >= 2.10'],
+    'dask': ['dask[array] >= 1.1.0'],
+    'jax': ['jax == 0.1.27', 'jaxlib == 0.1.14'],
+    'scipy': ['scipy >= 1.0.0'],
+    'astropy': ['astropy >= 2.0.0, < 3.0; python_version <= "2.7"',
+                'astropy >= 3.0; python_version >= "3.0"'],
+    'python-casacore': ['python-casacore >= 2.2.1, <= 3.0.0'],
+    'testing': ['pytest', 'pytest-runner', 'flaky']
+}
+
+_non_cuda_extras = [er for n, er in extras_require.items() if n != "cuda"]
+_all_extras = extras_require.values()
+
+extras_require['complete'] = sorted(set(sum(_non_cuda_extras, [])))
+extras_require['complete-cuda'] = sorted(set(sum(_all_extras, [])))
+
+setup_requirements = []
+test_requirements = (extras_require['testing'] +
+                     extras_require['astropy'] +
+                     extras_require['python-casacore'] +
+                     extras_require['dask'] +
+                     extras_require['scipy'])

--- a/africanus/install/requirements.py
+++ b/africanus/install/requirements.py
@@ -32,7 +32,7 @@ extras_require = {
     'scipy': ['scipy >= 1.0.0'],
     'astropy': ['astropy >= 2.0.0, < 3.0; python_version <= "2.7"',
                 'astropy >= 3.0; python_version >= "3.0"'],
-    'python-casacore': ['python-casacore >= 2.2.1, <= 3.0.0'],
+    'python-casacore': ['python-casacore == 3.0.0'],
     'testing': ['pytest', 'pytest-runner', 'flaky']
 }
 

--- a/africanus/rime/dask_predict.py
+++ b/africanus/rime/dask_predict.py
@@ -10,14 +10,13 @@ from operator import mul
 
 import numpy as np
 
-from africanus.compatibility import range, reduce
+from africanus.compatibility import range, reduce, Mapping
 from africanus.util.requirements import requires_optional
 
 from africanus.rime.predict import (PREDICT_DOCS, predict_checks,
                                     predict_vis as np_predict_vis)
 
 try:
-    from dask.compatibility import Mapping
     from dask.blockwise import blockwise
     from dask.base import tokenize
     import dask.array as da

--- a/africanus/rime/examples/predict.py
+++ b/africanus/rime/examples/predict.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import argparse
 
-from dask.diagnostics import ProgressBar
 import numpy as np
 
 
@@ -21,6 +20,7 @@ else:
 try:
     import dask
     import dask.array as da
+    from dask.diagnostics import ProgressBar
     import xarray as xr
     from xarrayms import xds_from_ms, xds_from_table, xds_to_table
 except ImportError as e:

--- a/africanus/rime/tests/test_parangles.py
+++ b/africanus/rime/tests/test_parangles.py
@@ -66,6 +66,7 @@ def _observation_endpoints(year, month, day, hour_duration):
     return (start, end)
 
 
+@pytest.mark.flaky(min_passes=1, max_runs=3)
 @pytest.mark.parametrize('backend', [
     'test',
     pytest.param('casa', marks=pytest.mark.skipif(
@@ -88,6 +89,7 @@ def test_parallactic_angles(observation, wsrt_ants, backend):
     assert pa.shape == (5, 4)
 
 
+@pytest.mark.flaky(min_passes=1, max_runs=3)
 @pytest.mark.skipif(no_casa or no_astropy,
                     reason="Neither python-casacore or astropy installed")
 # Parametrize on observation length and error tolerance
@@ -126,6 +128,7 @@ def test_compare_astropy_and_casa(obs_and_tol, wsrt_ants):
     assert np.all(np.abs(diff) < Angle(rtol))
 
 
+@pytest.mark.flaky(min_passes=1, max_runs=3)
 @pytest.mark.parametrize('backend', [
     'test',
     pytest.param('casa', marks=pytest.mark.skipif(

--- a/setup.py
+++ b/setup.py
@@ -1,52 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 """The setup script."""
 
 import os
 from setuptools import setup, find_packages
 
+# Import requirements
+from africanus.install.requirements import (requirements,
+                                            extras_require,
+                                            setup_requirements,
+                                            test_requirements)
+
 with open('README.rst') as readme_file:
     readme = readme_file.read()
-
-# requirements
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-
-# Basic requirements containing no C extensions.
-# This is necessary for building on RTD
-requirements = ['appdirs >= 1.4.3',
-                'decorator']
-
-if not on_rtd:
-    requirements += [
-        # astropy breaks with numpy 1.15.3
-        # https://github.com/astropy/astropy/issues/7943
-        'numpy >= 1.14.0, != 1.15.3',
-        'numba >= 0.43.0']
-
-extras_require = {
-    'cuda': ['cupy >= 5.0.0', 'jinja2 >= 2.10'],
-    'dask': ['dask[array] >= 1.1.0'],
-    'jax': ['jax == 0.1.27', 'jaxlib == 0.1.14'],
-    'scipy': ['scipy >= 1.0.0'],
-    'astropy': ['astropy >= 2.0.0, < 3.0; python_version <= "2.7"',
-                'astropy >= 3.0; python_version >= "3.0"'],
-    'python-casacore': ['python-casacore >= 2.2.1'],
-    'testing': ['pytest', 'pytest-runner']
-}
-
-_non_cuda_extras = [er for n, er in extras_require.items() if n != "cuda"]
-_all_extras = extras_require.values()
-
-extras_require['complete'] = sorted(set(sum(_non_cuda_extras, [])))
-extras_require['complete-cuda'] = sorted(set(sum(_all_extras, [])))
-
-setup_requirements = []
-test_requirements = (extras_require['testing'] +
-                     extras_require['astropy'] +
-                     extras_require['python-casacore'] +
-                     extras_require['dask'] +
-                     extras_require['scipy'])
 
 setup(
     author="Simon Perkins",


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
