### PR TITLE
Clarify die2_jones/dde2_jones in predict_vis docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 ------------------
 * Explain how to obtain predict_vis time_index argument (:pr:`130`)
 * Update RIME predict example to support Tigger LSM's and Gaussians (:pr:`129`)
-* Add dask wrappers for the nifty gridder (:pr:`116`)
+* Add dask wrappers for the nifty gridder (:pr:`116`, :pr:`136`)
 * Testing and requirement updates. (:pr:`124`)
 * Upgraded DFT kernels to have a correlation axis and added flags
   for vis_to_im. Added predict_from_fits example. (:pr:`122`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 0.1.9 (YYYY-MM-DD)
 ------------------
+
+* Clarify die2_jones/dde2_jones in predict_vis documentation (:pr:`135`)
 * Explain how to obtain predict_vis time_index argument (:pr:`130`)
 * Update RIME predict example to support Tigger LSM's and Gaussians (:pr:`129`)
 * Add dask wrappers for the nifty gridder (:pr:`116`, :pr:`136`)

--- a/africanus/gridding/nifty/dask.py
+++ b/africanus/gridding/nifty/dask.py
@@ -95,15 +95,15 @@ def _nifty_indices(baselines, grid_config, flag,
 def _nifty_grid(baselines, grid_config, indices, vis, weights):
     """ Wrapper function for creating a grid of visibilities per row chunk """
     assert len(vis) == 1 and type(vis) == list
-    return ng.ms2grid_c_wgt(baselines, grid_config, indices,
-                            vis[0], weights[0], None)[None, :, :]
+    return ng.ms2grid_c(baselines, grid_config, indices,
+                        vis[0], None, weights[0])[None, :, :]
 
 
 def _nifty_grid_streams(baselines, grid_config, indices,
                         vis, weights, grid_in=None):
     """ Wrapper function for creating a grid of visibilities per row chunk """
-    return ng.ms2grid_c_wgt(baselines, grid_config, indices,
-                            vis, weights, grid_in=grid_in)
+    return ng.ms2grid_c(baselines, grid_config, indices,
+                        vis, grid_in, weights)
 
 
 class GridStreamReduction(Mapping):

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -561,8 +561,9 @@ source_coh : $(array_type), optional
     with shape :code:`(source,row,chan,corr_1,corr_2)`
 dde2_jones : $(array_type), optional
     :math:`A_{qs}` Direction-Dependent Jones terms for the second antenna.
-    This is usually the array as ``dde1_jones`` in order to
-    preserve the symmetry of the RIME.
+    This is usually the same array as ``dde1_jones`` as this
+    preserves the symmetry of the RIME. ``predict_vis`` will
+    perform the conjugate transpose internally.
     shape :code:`(source,time,ant,chan,corr_1,corr_2)`
 die1_jones : $(array_type), optional
     :math:`G_{ps}` Direction-Independent Jones terms for the
@@ -575,9 +576,10 @@ base_vis : $(array_type), optional
 die2_jones : $(array_type), optional
     :math:`G_{ps}` Direction-Independent Jones terms for the
     second antenna of the baseline.
-    This is usually the array as ``die1_jones`` in order to
-    preserve the symmetry of the RIME.
-    with shape :code:`(time,ant,chan,corr_1,corr_2)`
+    This is usually the same array as ``die1_jones`` as this
+    preserves the symmetry of the RIME. ``predict_vis`` will
+    perform the conjugate transpose internally.
+    shape :code:`(time,ant,chan,corr_1,corr_2)`
 $(extra_args)
 
 Returns

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -561,6 +561,8 @@ source_coh : $(array_type), optional
     with shape :code:`(source,row,chan,corr_1,corr_2)`
 dde2_jones : $(array_type), optional
     :math:`A_{qs}` Direction-Dependent Jones terms for the second antenna.
+    This is usually the array as ``dde1_jones`` in order to
+    preserve the symmetry of the RIME.
     shape :code:`(source,time,ant,chan,corr_1,corr_2)`
 die1_jones : $(array_type), optional
     :math:`G_{ps}` Direction-Independent Jones terms for the
@@ -573,6 +575,8 @@ base_vis : $(array_type), optional
 die2_jones : $(array_type), optional
     :math:`G_{ps}` Direction-Independent Jones terms for the
     second antenna of the baseline.
+    This is usually the array as ``die1_jones`` in order to
+    preserve the symmetry of the RIME.
     with shape :code:`(time,ant,chan,corr_1,corr_2)`
 $(extra_args)
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
