### PR TITLE
Fix nifty upstream changes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 ------------------
 * Explain how to obtain predict_vis time_index argument (:pr:`130`)
 * Update RIME predict example to support Tigger LSM's and Gaussians (:pr:`129`)
-* Add dask wrappers for the nifty gridder (:pr:`116`)
+* Add dask wrappers for the nifty gridder (:pr:`116`, :pr:`136`)
 * Testing and requirement updates. (:pr:`124`)
 * Upgraded DFT kernels to have a correlation axis and added flags
   for vis_to_im. Added predict_from_fits example. (:pr:`122`)

--- a/africanus/gridding/nifty/dask.py
+++ b/africanus/gridding/nifty/dask.py
@@ -95,15 +95,15 @@ def _nifty_indices(baselines, grid_config, flag,
 def _nifty_grid(baselines, grid_config, indices, vis, weights):
     """ Wrapper function for creating a grid of visibilities per row chunk """
     assert len(vis) == 1 and type(vis) == list
-    return ng.ms2grid_c_wgt(baselines, grid_config, indices,
-                            vis[0], weights[0], None)[None, :, :]
+    return ng.ms2grid_c(baselines, grid_config, indices,
+                        vis[0], None, weights[0])[None, :, :]
 
 
 def _nifty_grid_streams(baselines, grid_config, indices,
                         vis, weights, grid_in=None):
     """ Wrapper function for creating a grid of visibilities per row chunk """
-    return ng.ms2grid_c_wgt(baselines, grid_config, indices,
-                            vis, weights, grid_in=grid_in)
+    return ng.ms2grid_c(baselines, grid_config, indices,
+                        vis, grid_in, weights)
 
 
 class GridStreamReduction(Mapping):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
