### PR TITLE
Set row chunks to nan (unknown) in dask averager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   - env: TARGET=python2
   - env: TARGET=python35
   - env: TARGET=python36
-  - env: TARGET=pep8
 sudo: required
 services:
 - docker

--- a/.travis/pep8.docker
+++ b/.travis/pep8.docker
@@ -1,7 +1,0 @@
-FROM kernsuite/base:5
-RUN docker-apt-install python3-pip
-RUN pip3 install pycodestyle flake8
-ADD . /code
-WORKDIR /code
-RUN flake8 africanus
-RUN pycodestyle africanus

--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -10,11 +10,11 @@ WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip install .[testing]
-RUN py.test -s -vvv /code/africanus
+RUN py.test --flake8 -s -vvv /code/africanus
 
 # Test most functionality
 # Install kern python-casacore to avoid build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python-casacore
 RUN pip install .[astropy,dask,scipy,testing]
 RUN pip install git+https://gitlab.mpcdf.mpg.de/ift/nifty_gridder.git
-RUN py.test -s -vvv /code/africanus
+RUN py.test --flake8 -s -vvv /code/africanus

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -10,11 +10,11 @@ WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip3 install .[testing]
-RUN py.test -s -vvv /code/africanus
+RUN py.test --flake8 -s -vvv /code/africanus
 
 # Test most functionality.
 # Install kern python-casacore to avoid build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-casacore
 RUN pip3 install .[astropy,dask,scipy,testing]
 RUN pip3 install git+https://gitlab.mpcdf.mpg.de/ift/nifty_gridder.git
-RUN py.test -s -vvv /code/africanus
+RUN py.test --flake8 -s -vvv /code/africanus

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -10,11 +10,11 @@ WORKDIR /code
 # Test base install without optional installs works
 # Most of the tests will be skipped
 RUN pip3 install .[testing]
-RUN py.test -s -vvv /code/africanus
+RUN py.test --flake8 -s -vvv /code/africanus
 
 # Test most functionality
 # Install kern python-casacore to avoid build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-casacore
 RUN pip3 install .[astropy,dask,scipy,testing]
 RUN pip3 install git+https://gitlab.mpcdf.mpg.de/ift/nifty_gridder.git
-RUN py.test -s -vvv /code/africanus
+RUN py.test --flake8 -s -vvv /code/africanus

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
+* Set row chunks to nan in dask averaging code. (:pr:`139`)
 * Clarify die2_jones/dde2_jones in predict_vis documentation (:pr:`135`)
 * Upgrade to dask-ms in the examples (:pr:`134`, :pr:`138`)
 * Explain how to obtain predict_vis time_index argument (:pr:`130`)

--- a/africanus/averaging/dask.py
+++ b/africanus/averaging/dask.py
@@ -60,6 +60,7 @@ def _dask_row_mapper(time, interval, antenna1, antenna2,
                         antenna1, ("row",),
                         antenna2, ("row",),
                         flag_row, None if flag_row is None else ("row",),
+                        adjust_chunks={"row": lambda x: np.nan},
                         time_bin_secs=time_bin_secs,
                         dtype=np.object)
 
@@ -93,6 +94,7 @@ def _dask_row_average(row_meta, ant1, ant2, flag_row=None,
                        uvw, None if uvw is None else ("row", "3"),
                        weight, None if weight is None else rcd,
                        sigma, None if sigma is None else rcd,
+                       align_arrays=False,
                        adjust_chunks={"row": lambda x: np.nan},
                        dtype=np.object)
 
@@ -126,6 +128,9 @@ def _dask_row_chan_average(row_meta, chan_meta, flag_row=None, weight=None,
                            chan_bin_size=1):
     """ Average (row,chan,corr)-based dask arrays """
 
+    if chan_meta is None:
+        return RowChanAverageOutput(None, None, None, None)
+
     # We don't know how many rows are in each row chunk,
     # but we can simply divide each channel chunk size by the bin size
     adjust_chunks = {
@@ -149,6 +154,7 @@ def _dask_row_chan_average(row_meta, chan_meta, flag_row=None, weight=None,
                        flag, flag_dims,
                        weight_spectrum, ws_dims,
                        sigma_spectrum, ss_dims,
+                       align_arrays=False,
                        adjust_chunks=adjust_chunks,
                        dtype=np.object)
 
@@ -173,6 +179,10 @@ def _getitem_chan(avg, idx, dtype):
 
 def _dask_chan_average(chan_meta, chan_freq=None, chan_width=None,
                        chan_bin_size=1):
+
+    if chan_meta is None:
+        return ChannelAverageOutput(None, None)
+
     adjust_chunks = {
         "chan": lambda c: (c + chan_bin_size - 1) // chan_bin_size
     }

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -387,26 +387,116 @@ def chan_normaliser_factory(present):
     return njit(nogil=True, cache=True)(impl)
 
 
-def chan_corr_factory(have_vis, have_flag,
-                      have_weight_spectrum, have_sigma_spectrum):
-    """ Returns function returning number of channels and correlations """
-    if have_vis:
-        def impl(vis, flag, weight_spectrum, sigma_spectrum):
-            return vis.shape[1:]
-    elif have_flag:
-        def impl(vis, flag, weight_spectrum, sigma_spectrum):
-            return flag.shape[1:]
-    elif have_weight_spectrum:
-        def impl(vis, flag, weight_spectrum, sigma_spectrum):
-            return weight_spectrum.shape[1:]
-    elif have_sigma_spectrum:
-        def impl(vis, flag, weight_spectrum, sigma_spectrum):
-            return sigma_spectrum.shape[1:]
-    else:
-        def impl(vis, flag, weight_spectrum, sigma_spectrum):
-            return (1, 1)
+@generated_jit(nopython=True, nogil=True, cache=True)
+def shape_or_invalid_shape(array, ndim):
+    """ Return array shape tuple or (-1,)*ndim if the array is None """
 
-    return njit(nogil=True, cache=True)(impl)
+    try:
+        ndim_lit = getattr(ndim, "literal_value")
+    except AttributeError:
+        raise ValueError("ndim must be a integer literal")
+
+    if is_numba_type_none(array):
+        tup = (-1,)*ndim_lit
+
+        def impl(array, ndim):
+            return tup
+    else:
+        def impl(array, ndim):
+            return array.shape
+
+    return impl
+
+
+@njit(nogil=True, cache=True)
+def find_chan_corr(chan, corr, shape, chan_idx, corr_idx):
+    """
+    1. Get channel and correlation from shape if not set and the shape is valid
+    2. Check they agree if they already agree
+
+    Parameters
+    ----------
+    chan : int
+        Existing channel size
+    corr : int
+        Existing correlation size
+    shape : tuple
+        Array shape tuple
+    chan_idx : int
+        Index of channel dimension in ``shape``.
+    corr_idx : int
+        Index of correlation dimension in ``shape``.
+
+    Returns
+    -------
+    int
+        Modified channel size
+    int
+        Modified correlation size
+    """
+    if chan_idx != -1:
+        array_chan = shape[chan_idx]
+
+        # Corresponds to a None array, ignore
+        if array_chan == -1:
+            pass
+        # chan is not yet set, assign
+        elif chan == 0:
+            chan = array_chan
+        # Check consistency
+        elif chan != array_chan:
+            raise ValueError("Inconsistent Channel Dimension "
+                             "in Input Arrays")
+
+    if corr_idx != -1:
+        array_corr = shape[corr_idx]
+
+        # Corresponds to a None array, ignore
+        if array_corr == -1:
+            pass
+        # corr is not yet set, assign
+        elif corr == 0:
+            corr = array_corr
+        # Check consistency
+        elif corr != array_corr:
+            raise ValueError("Inconsistent Correlation Dimension "
+                             "in Input Arrays")
+
+    return chan, corr
+
+
+@njit(nogil=True, cache=True)
+def chan_corrs(vis, flag,
+               weight_spectrum, sigma_spectrum,
+               chan_freq, chan_width):
+    """
+    Infer channel and correlation size from input dimensions
+
+    Returns
+    -------
+    int
+        channel size
+    int
+        correlation size
+    """
+    vis_shape = shape_or_invalid_shape(vis, 3)
+    flag_shape = shape_or_invalid_shape(flag, 3)
+    weight_spectrum_shape = shape_or_invalid_shape(weight_spectrum, 3)
+    sigma_spectrum_shape = shape_or_invalid_shape(sigma_spectrum, 3)
+    chan_freq_shape = shape_or_invalid_shape(chan_freq, 1)
+    chan_width_shape = shape_or_invalid_shape(chan_width, 1)
+
+    chan = 0
+    corr = 0
+
+    chan, corr = find_chan_corr(chan, corr, vis_shape, 1, 2)
+    chan, corr = find_chan_corr(chan, corr, flag_shape, 1, 2)
+    chan, corr = find_chan_corr(chan, corr, weight_spectrum_shape, 1, 2)
+    chan, corr = find_chan_corr(chan, corr, sigma_spectrum_shape, 1, 2)
+    chan, corr = find_chan_corr(chan, corr, chan_freq_shape, 0, -1)
+    chan, corr = find_chan_corr(chan, corr, chan_width_shape, 0, -1)
+
+    return chan, corr
 
 
 def is_chan_flagged_factory(present):
@@ -476,16 +566,19 @@ def row_chan_average(row_meta, chan_meta, flag_row=None, weight=None,
 
     set_flagged = set_flagged_factory(have_flag)
 
-    chan_corrs = chan_corr_factory(have_vis, have_flag,
-                                   have_weight_spectrum, have_sigma_spectrum)
+    dummy_chan_freq = None
+    dummy_chan_width = None
 
     def impl(row_meta, chan_meta, flag_row=None, weight=None,
              vis=None, flag=None,
              weight_spectrum=None, sigma_spectrum=None):
 
         out_rows = row_meta.time.shape[0]
+        nchan, ncorrs = chan_corrs(vis, flag,
+                                   weight_spectrum, sigma_spectrum,
+                                   dummy_chan_freq, dummy_chan_width)
+
         chan_map, out_chans = chan_meta
-        _, ncorrs = chan_corrs(vis, flag, weight_spectrum, sigma_spectrum)
 
         out_shape = (out_rows, out_chans, ncorrs)
 
@@ -716,10 +809,6 @@ def time_and_channel(time, interval, antenna1, antenna2,
     have_weight_spectrum = not is_numba_type_none(weight_spectrum)
     have_sigma_spectrum = not is_numba_type_none(sigma_spectrum)
 
-    chan_corrs = chan_corr_factory(have_vis, have_flag,
-                                   have_weight_spectrum,
-                                   have_sigma_spectrum)
-
     def impl(time, interval, antenna1, antenna2,
              time_centroid=None, exposure=None, flag_row=None,
              uvw=None, weight=None, sigma=None,
@@ -728,8 +817,9 @@ def time_and_channel(time, interval, antenna1, antenna2,
              weight_spectrum=None, sigma_spectrum=None,
              time_bin_secs=1.0, chan_bin_size=1):
 
-        # Get the number of channels + correlations
-        nchan, ncorr = chan_corrs(vis, flag, weight_spectrum, sigma_spectrum)
+        nchan, ncorrs = chan_corrs(vis, flag,
+                                   weight_spectrum, sigma_spectrum,
+                                   chan_freq, chan_width)
 
         # Merge flag_row and flag arrays
         flag_row = merge_flags(flag_row, flag)

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -804,11 +804,6 @@ def time_and_channel(time, interval, antenna1, antenna2,
     if not isinstance(chan_bin_size, valid_types):
         raise TypeError("chan_bin_size must be a scalar integer")
 
-    have_vis = not is_numba_type_none(vis)
-    have_flag = not is_numba_type_none(flag)
-    have_weight_spectrum = not is_numba_type_none(weight_spectrum)
-    have_sigma_spectrum = not is_numba_type_none(sigma_spectrum)
-
     def impl(time, interval, antenna1, antenna2,
              time_centroid=None, exposure=None, flag_row=None,
              uvw=None, weight=None, sigma=None,

--- a/africanus/deconv/hogbom/clean.py
+++ b/africanus/deconv/hogbom/clean.py
@@ -8,8 +8,16 @@ import logging
 
 import numba
 import numpy as np
-import scipy.signal
-from scipy import optimize as opt
+
+try:
+    import scipy.signal
+    from scipy import optimize as opt
+except ImportError as e:
+    opt_import_err = e
+else:
+    opt_import_err = None
+
+from africanus.util.requirements import requires_optional
 
 
 @numba.jit(nopython=True, nogil=True, cache=True)
@@ -28,6 +36,7 @@ def twod_gaussian(coords, amplitude, xo, yo, sigma_x, sigma_y, theta, offset):
     return g.flatten()
 
 
+@requires_optional('scipy', opt_import_err)
 def fit_2d_gaussian(psf):
     """
     Fit an elliptical Gaussian to the primary lobe of the psf
@@ -188,6 +197,7 @@ def hogbom_clean(dirty, psf,
     return clean, residuals
 
 
+@requires_optional("scipy", opt_import_err)
 def restore(clean, psf, residuals):
     """
     Parameters

--- a/africanus/install/requirements.py
+++ b/africanus/install/requirements.py
@@ -33,7 +33,7 @@ extras_require = {
     'astropy': ['astropy >= 2.0.0, < 3.0; python_version <= "2.7"',
                 'astropy >= 3.0; python_version >= "3.0"'],
     'python-casacore': ['python-casacore == 3.0.0'],
-    'testing': ['pytest', 'pytest-runner', 'flaky']
+    'testing': ['pytest', 'flaky', 'pytest-flake8']
 }
 
 _non_cuda_extras = [er for n, er in extras_require.items() if n != "cuda"]


### PR DESCRIPTION
Also, previously channel was only inferred from vis, flags,
and {weight,sigma}_spectrum. Extend this to include chan_{freq,width}.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
