### PR TITLE
Make predict_vis docstrings consistent

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
-* Clarify die2_jones/dde2_jones in predict_vis documentation (:pr:`135`)
+* predict_vis documentation improvements (:pr:`135`, :pr:`140`)
 * Upgrade to dask-ms in the examples (:pr:`134`, :pr:`138`)
 * Explain how to obtain predict_vis time_index argument (:pr:`130`)
 * Update RIME predict example to support Tigger LSM's and Gaussians (:pr:`129`)

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -508,7 +508,7 @@ to the following formula:
 
 
     V_{pq} = G_{p} \left(
-        B_{pq} + \sum_{s} A_{ps} X_{pqs} A_{qs}^H
+        B_{pq} + \sum_{s} E_{ps} X_{pqs} E_{qs}^H
         \right) G_{q}^H
 
 where for antenna :math:`p` and :math:`q`, and source :math:`s`:
@@ -554,13 +554,13 @@ antenna2 : $(array_type)
     for a particular baseline.
     with shape :code:`(row,)`.
 dde1_jones : $(array_type), optional
-    :math:`A_{ps}` Direction-Dependent Jones terms for the first antenna.
+    :math:`E_{ps}` Direction-Dependent Jones terms for the first antenna.
     shape :code:`(source,time,ant,chan,corr_1,corr_2)`
 source_coh : $(array_type), optional
     :math:`X_{pqs}` Direction-Dependent Coherency matrix for the baseline.
     with shape :code:`(source,row,chan,corr_1,corr_2)`
 dde2_jones : $(array_type), optional
-    :math:`A_{qs}` Direction-Dependent Jones terms for the second antenna.
+    :math:`E_{qs}` Direction-Dependent Jones terms for the second antenna.
     This is usually the same array as ``dde1_jones`` as this
     preserves the symmetry of the RIME. ``predict_vis`` will
     perform the conjugate transpose internally.
@@ -570,7 +570,7 @@ die1_jones : $(array_type), optional
     first antenna of the baseline.
     with shape :code:`(time,ant,chan,corr_1,corr_2)`
 base_vis : $(array_type), optional
-    :math:`B_{pq}` base visibilities, added to source coherency summation
+    :math:`B_{pq}` base coherencies, added to source coherency summation
     *before* multiplication with `die1_jones` and `die2_jones`.
     shape :code:`(row,chan,corr_1,corr_2)`.
 die2_jones : $(array_type), optional


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
