### PR TITLE
Remove use of @wraps with dask wrapped functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
-* Fix function wrapping (:pr:`141`)
+* Remove use of @wraps (:pr:`141`, :pr:`142`)
 * Set row chunks to nan in dask averaging code. (:pr:`139`)
 * predict_vis documentation improvements (:pr:`135`, :pr:`140`)
 * Upgrade to dask-ms in the examples (:pr:`134`, :pr:`138`)

--- a/africanus/averaging/dask.py
+++ b/africanus/averaging/dask.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
 from operator import getitem
 
 from africanus.averaging.time_and_channel_mapping import (row_mapper,
@@ -90,7 +89,6 @@ def _getitem_row(avg, idx, array, dims):
     return da.Array(graph, name, chunks, dtype=array.dtype, **kw)
 
 
-@wraps(row_average)
 def _row_average_wrapper(row_meta, ant1, ant2, flag_row,
                          time_centroid, exposure, uvw,
                          weight, sigma):

--- a/africanus/coordinates/dask.py
+++ b/africanus/coordinates/dask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
-
 try:
     import dask.array as da
 except ImportError as e:
@@ -23,7 +21,6 @@ from africanus.coordinates.coordinates import (radec_to_lmn as np_radec_to_lmn,
                                                LMN_TO_RADEC_DOCS)
 
 
-@wraps(np_radec_to_lmn)
 def _radec_to_lmn(radec, phase_centre):
     return np_radec_to_lmn(radec[0], phase_centre[0] if phase_centre else None)
 
@@ -39,7 +36,6 @@ def radec_to_lmn(radec, phase_centre=None):
                              dtype=radec.dtype)
 
 
-@wraps(np_lmn_to_radec)
 def _lmn_to_radec(lmn, phase_centre):
     return np_lmn_to_radec(lmn[0], phase_centre)
 
@@ -55,7 +51,6 @@ def lmn_to_radec(lmn, phase_centre=None):
                              dtype=lmn.dtype)
 
 
-@wraps(np_radec_to_lm)
 def _radec_to_lm(radec, phase_centre):
     return np_radec_to_lm(radec[0], phase_centre[0] if phase_centre else None)
 
@@ -71,7 +66,6 @@ def radec_to_lm(radec, phase_centre=None):
                              dtype=radec.dtype)
 
 
-@wraps(np_lm_to_radec)
 def _lm_to_radec(lm, phase_centre):
     return np_lm_to_radec(lm[0], phase_centre)
 

--- a/africanus/dft/dask.py
+++ b/africanus/dft/dask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
-
 from africanus.dft.kernels import im_to_vis_docs, vis_to_im_docs
 from africanus.dft.kernels import im_to_vis as np_im_to_vis
 from africanus.dft.kernels import vis_to_im as np_vis_to_im
@@ -23,7 +21,6 @@ else:
     dask_import_error = None
 
 
-@wraps(np_im_to_vis)
 def _im_to_vis_wrapper(image, uvw, lm, frequency, dtype_):
     return np_im_to_vis(image[0], uvw[0], lm[0][0],
                         frequency, dtype=dtype_)
@@ -53,7 +50,6 @@ def im_to_vis(image, uvw, lm, frequency, dtype=np.complex128):
                              dtype_=dtype)
 
 
-@wraps(np_vis_to_im)
 def _vis_to_im_wrapper(vis, uvw, lm, frequency, flags, dtype_):
     return np_vis_to_im(vis, uvw[0], lm[0],
                         frequency, flags,

--- a/africanus/model/coherency/dask.py
+++ b/africanus/model/coherency/dask.py
@@ -4,13 +4,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
 
 from africanus.compatibility import range
 
 from africanus.model.coherency.conversion import (convert_setup,
                                                   convert_impl,
-                                                  convert as np_stokes_convert,
                                                   CONVERT_DOCS)
 
 from africanus.util.requirements import requires_optional
@@ -23,8 +21,6 @@ else:
     da_import_error = None
 
 
-# This wraps is a https://en.wikipedia.org/wiki/Noble_lie
-@wraps(np_stokes_convert)
 def _wrapper(np_input, mapping=None, in_shape=None,
              out_shape=None, dtype_=None):
     result = convert_impl(np_input, mapping, in_shape,

--- a/africanus/model/spectral/dask.py
+++ b/africanus/model/spectral/dask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
-
 from africanus.model.spectral.spec_model import (
                                         spectral_model as np_spectral_model,
                                         SPECTRAL_MODEL_DOC)
@@ -19,7 +17,6 @@ else:
     opt_import_error = None
 
 
-@wraps(np_spectral_model)
 def _wrapper(stokes, spi, ref_freq, frequencies, base=None):
     return np_spectral_model(stokes, spi[0], ref_freq, frequencies, base=base)
 

--- a/africanus/model/spi/dask.py
+++ b/africanus/model/spi/dask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
-
 from africanus.model.spi.component_spi import SPI_DOCSTRING
 from africanus.model.spi.component_spi import (
                                 fit_spi_components as np_fit_spi_components)
@@ -22,7 +20,6 @@ else:
     opt_import_error = None
 
 
-@wraps(np_fit_spi_components)
 def _fit_spi_components_wrapper(data, weights, freqs, freq0,
                                 alphai, I0i, tol_, maxiter_,
                                 dtype_):

--- a/africanus/rime/dask.py
+++ b/africanus/rime/dask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
-
 from africanus.rime.phase import (phase_delay as np_phase_delay,
                                   PHASE_DELAY_DOCS)
 from africanus.rime.parangles import parallactic_angles as np_parangles
@@ -32,7 +30,6 @@ else:
     da_import_error = None
 
 
-@wraps(np_phase_delay)
 def _phase_delay_wrap(lm, uvw, frequency):
     return np_phase_delay(lm[0], uvw[0], frequency)
 
@@ -47,7 +44,6 @@ def phase_delay(lm, uvw, frequency):
                              dtype=infer_complex_dtype(lm, uvw, frequency))
 
 
-@wraps(np_parangles)
 def _parangle_wrapper(t, ap, fc, **kw):
     return np_parangles(t, ap[0], fc[0], **kw)
 
@@ -83,7 +79,6 @@ def feed_rotation(parallactic_angles, feed_type):
                              dtype=dtype)
 
 
-@wraps(np_transform_sources)
 def _xform_wrap(lm, parallactic_angles, pointing_errors,
                 antenna_scaling, frequency, dtype_):
     return np_transform_sources(lm[0], parallactic_angles,
@@ -111,7 +106,6 @@ def transform_sources(lm, parallactic_angles, pointing_errors,
                              dtype_=dtype)
 
 
-@wraps(np_beam_cube_dde)
 def _beam_cube_dde_wrapper(beam, beam_lm_extents, beam_freq_map,
                            lm, parallactic_angles,
                            point_errors, antenna_scaling,
@@ -155,7 +149,6 @@ def beam_cube_dde(beam, beam_lm_extents, beam_freq_map,
                              dtype=beam.dtype)
 
 
-@wraps(np_zernike_dde)
 def _zernike_wrapper(coords, coeffs, noll_index):
     # coords loses "three" dim
     # coeffs loses "poly" dim

--- a/africanus/rime/dask_predict.py
+++ b/africanus/rime/dask_predict.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from functools import wraps
 from itertools import product
 from operator import mul
 
@@ -239,7 +238,6 @@ class CoherencyFinalReduction(Mapping):
         return layers
 
 
-@wraps(np_predict_vis)
 def _predict_coh_wrapper(time_index, antenna1, antenna2,
                          dde1_jones, source_coh, dde2_jones,
                          die1_jones, base_vis, die2_jones):
@@ -260,7 +258,6 @@ def _predict_coh_wrapper(time_index, antenna1, antenna2,
             [None, ...])
 
 
-@wraps(np_predict_vis)
 def _predict_dies_wrapper(time_index, antenna1, antenna2,
                           dde1_jones, source_coh, dde2_jones,
                           die1_jones, base_vis, die2_jones):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
