### PR TITLE
Fix builtins on python3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 
 * Deprecate experimental w-stacking gridder in favour of nifty gridder (:pr:`148`)
 * Expand travis build matrix (:pr:`147`)
-* Drop Python 2 support (:pr:`146`, :pr:`149`)
+* Drop Python 2 support (:pr:`146`, :pr:`149`, :pr:`150`)
 * Support the beam in the predict example (:pr:`145`)
 * Fix weight indexing in averaging (:pr:`144`)
 * Support EFFECTIVE_BW and RESOLUTION in averaging (:pr:`144`)

--- a/africanus/util/cmdline.py
+++ b/africanus/util/cmdline.py
@@ -3,12 +3,11 @@
 
 
 import ast
-
-import __builtin__
+import builtins
 
 # builtin function whitelist
 _BUILTIN_WHITELIST = frozenset(['slice'])
-_missing = _BUILTIN_WHITELIST.difference(dir(__builtin__))
+_missing = _BUILTIN_WHITELIST.difference(dir(builtins))
 if len(_missing) > 0:
     raise ValueError("'%s' are not valid builtin functions.'" % list(_missing))
 
@@ -69,7 +68,7 @@ def parse_python_assigns(assign_str):
             else:
                 kwargs = {}
 
-            return getattr(__builtin__, func_name)(*args, **kwargs)
+            return getattr(builtins, func_name)(*args, **kwargs)
         # Try a literal eval
         else:
             return ast.literal_eval(stmt_value)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
