### PR TITLE
Fix RTD by setting versions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
+* Fix documentation package versions (:pr:`151`)
 * Deprecate experimental w-stacking gridder in favour of nifty gridder (:pr:`148`)
 * Expand travis build matrix (:pr:`147`)
 * Drop Python 2 support (:pr:`146`, :pr:`149`, :pr:`150`)

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,3 +1,2 @@
-numpydoc==0.9.1
-sphinx==2.2.0
-dask_sphinx_theme>=1.1.0
+numpydoc==0.7.0
+sphinx==1.8.5

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,4 +1,3 @@
-numpydoc==0.8
-sphinx
+numpydoc==0.9.1
+sphinx==2.2.0
 dask_sphinx_theme>=1.1.0
-numpy


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
