### PR TITLE
Fail earlier on duplicate averaging rows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.9 (YYYY-MM-DD)
 ------------------
 
+* Fail earlier and explain duplicate averaging rows (:pr:`155`)
 * CUDA Beam Implementation (:pr:`152`)
 * Fix documentation package versions (:pr:`151`)
 * Deprecate experimental w-stacking gridder in favour of nifty gridder (:pr:`148`)

--- a/africanus/averaging/time_and_channel_avg.py
+++ b/africanus/averaging/time_and_channel_avg.py
@@ -937,6 +937,14 @@ chan_bin_size : int, optional
     Number of bins to average together.
     Defaults to 1.
 
+Notes
+-----
+
+The implementation currently requires unique lexicographical
+combinations of (TIME, ANTENNA1, ANTENNA2). This can usually
+be achieved by suitably partitioning input data on indexing rows,
+DATA_DESC_ID and SCAN_NUMBER in particular.
+
 Returns
 -------
 namedtuple

--- a/africanus/averaging/time_and_channel_mapping.py
+++ b/africanus/averaging/time_and_channel_mapping.py
@@ -202,6 +202,7 @@ def row_mapper(time, interval, antenna1, antenna2,
         time_lookup = np.zeros((nbl, ntime), dtype=time.dtype)
         interval_lookup = np.zeros((nbl, ntime), dtype=interval.dtype)
 
+        # Is the entire bin flagged?
         bin_flagged = np.zeros((nbl, ntime), dtype=np.bool_)
 
         # Create a mapping from the full bl x time resolution back
@@ -209,7 +210,16 @@ def row_mapper(time, interval, antenna1, antenna2,
         for r in range(time.shape[0]):
             bl = bl_inv[r]
             t = time_inv[r]
-            row_lookup[bl, t] = r
+
+            if row_lookup[bl, t] == -1:
+                row_lookup[bl, t] = r
+            else:
+                raise ValueError("Duplicate (TIME, ANTENNA1, ANTENNA2) "
+                                 "combinations were discovered in the input "
+                                 "data. This is usually caused by not "
+                                 "partitioning your data sufficiently "
+                                 "by indexing columns, DATA_DESC_ID "
+                                 "and SCAN_NUMBER in particular.")
 
         # Average times over each baseline and construct the
         # bin_lookup and time_lookup arrays

--- a/docs/averaging-api.rst
+++ b/docs/averaging-api.rst
@@ -33,6 +33,14 @@ Baseline T0  T1  T2  T3  T4
 It is possible for times or baselines to be missing. In the above
 example, T2 is missing for baseline (0, 2).
 
+.. warning::
+
+  The above requires unique lexicographical
+  combinations of (TIME, ANTENNA1, ANTENNA2). This can usually
+  be achieved by suitably partitioning input data on indexing rows,
+  DATA_DESC_ID and SCAN_NUMBER in particular.
+
+
 For each baseline, adjacent time's are assigned to a bin
 if :math:`h_c - h_e/2 - (l_c - l_e/2) <` :code:`time_bin_secs`, where
 :math:`h_c` and :math:`l_c` are the upper and lower time and


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
