### PR TITLE
Modify predict to work with eidos beams

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,12 @@
 History
 =======
 
+0.2.1 (YYYY-MM-DD)
+------------------
+* Modified predict to be compatible with eidos fits headers (:pr:`158`)
+
 0.2.0 (2019-09-30)
 ------------------
-* Modiefied predict to be compatible with eidos fits headers (:pr:`158`)
 * Added standalone SPI fitter (:pr:`153`)
 * Fail earlier and explain duplicate averaging rows (:pr:`155`)
 * CUDA Beam Implementation (:pr:`152`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.0 (2019-09-30)
 ------------------
+* Modiefied predict to be compatible with eidos fits headers (:pr:`158`)
 * Added standalone SPI fitter (:pr:`153`)
 * Fail earlier and explain duplicate averaging rows (:pr:`155`)
 * CUDA Beam Implementation (:pr:`152`)

--- a/africanus/rime/examples/predict.py
+++ b/africanus/rime/examples/predict.py
@@ -160,8 +160,14 @@ def load_beams(beam_file_schema, corr_types):
         beam_files.append((corr, (re_f, im_f)))
         headers.append((corr, (re_f.hdul[0].header, im_f.hdul[0].header)))
 
-    # All FITS headers should agree
-    flat_headers = [d for k, v in headers for d in v]
+    # All FITS headers should agree (apart from DATE)
+    flat_headers = []
+
+    for corr, (re_header, im_header) in headers:
+        del re_header["DATE"]
+        del im_header["DATE"]
+        flat_headers.append(re_header)
+        flat_headers.append(im_header)
 
     if not all(flat_headers[0] == h for h in flat_headers[1:]):
         raise ValueError("BEAM FITS Header Files differ")

--- a/africanus/util/beams.py
+++ b/africanus/util/beams.py
@@ -158,19 +158,19 @@ def beam_grids(header):
 
     # Find the relevant axes
     for i in range(beam_axes.ndims):
-        if beam_axes.ctype[i] in ('L', 'X', 'px'):
+        if beam_axes.ctype[i].upper() in ('L', 'X', 'PX'):
             l = i  # noqa
-        elif beam_axes.ctype[i] in ('M', 'Y', 'py'):
+        elif beam_axes.ctype[i].upper() in ('M', 'Y', 'PY'):
             m = i
         elif beam_axes.ctype[i] == "FREQ":
             freq = i
 
     # Complain if not found
     if l is None:
-        raise ValueError("No L/X/px axis present in FITS header")
+        raise ValueError("No L/X/PX axis present in FITS header")
 
     if m is None:
-        raise ValueError("No M/Y/py axis present in FITS header")
+        raise ValueError("No M/Y/PY axis present in FITS header")
 
     if freq is None:
         raise ValueError("No FREQ axis present in FITS header")

--- a/africanus/util/beams.py
+++ b/africanus/util/beams.py
@@ -158,19 +158,19 @@ def beam_grids(header):
 
     # Find the relevant axes
     for i in range(beam_axes.ndims):
-        if beam_axes.ctype[i] in ('L', 'X'):
+        if beam_axes.ctype[i] in ('L', 'X', 'px'):
             l = i  # noqa
-        elif beam_axes.ctype[i] in ('M', 'Y'):
+        elif beam_axes.ctype[i] in ('M', 'Y', 'py'):
             m = i
         elif beam_axes.ctype[i] == "FREQ":
             freq = i
 
     # Complain if not found
     if l is None:
-        raise ValueError("No L/X axis present in FITS header")
+        raise ValueError("No L/X/px axis present in FITS header")
 
     if m is None:
-        raise ValueError("No M/Y axis present in FITS header")
+        raise ValueError("No M/Y/py axis present in FITS header")
 
     if freq is None:
         raise ValueError("No FREQ axis present in FITS header")


### PR DESCRIPTION
MOdified predict so it does not insist that beam fits headers have the same DATE entries and to allow the CTYPE's to include px and py since this is how eidos spits them out