### PR TITLE
Document and check weight shapes in simple degridder

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.1 (YYYY-MM-DD)
 ------------------
+* Document and check weight shapes in simple degridder (:pr:`162`)
 * Restructuring calibration module (:pr:`127`)
 * Upgrade to numba 0.46.0, using new inlining functionality
   in the RIME and averaging code.

--- a/africanus/gridding/simple/gridding.py
+++ b/africanus/gridding/simple/gridding.py
@@ -182,6 +182,10 @@ def numba_degrid(grid, uvw, weights, ref_wave,
     See :func:"~africanus.gridding.simple.gridding.degrid" for
     documentation.
     """
+
+    if vis.shape != weights.shape:
+        raise ValueError("vis.shape != weights.shape")
+
     cf = convolution_filter
     ny, nx, flat_corrs = grid.shape
 
@@ -267,7 +271,8 @@ def degrid(grid, uvw, weights, ref_wave,
         float64 array of UVW coordinates of shape :code:`(row, 3)`
         in wavelengths.
     weights : np.ndarray
-        float32 or float64 array of weights. Set this to
+        float32 or float64 array of weights of
+        shape :code:`(row, chan, corr_1, corr_2)`. Set this to
         ``np.ones_like(vis, dtype=np.float32)`` as default.
     ref_wave : np.ndarray
         float64 array of wavelengths of shape :code:`(chan,)`


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
