### PR TITLE
Fix spacing in wsclean docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.1 (YYYY-MM-DD)
 ------------------
-* Implement optimised WSClean predict (:pr:`166`)
+* Implement optimised WSClean predict (:pr:`166`, :pr:`167`)
 * Simplify dask predict_vis code (:pr:`164`, :pr:`165`)
 * Document and check weight shapes in simple gridder and degridder
   (:pr:`162`, :pr:`163`)

--- a/africanus/rime/wsclean_predict.py
+++ b/africanus/rime/wsclean_predict.py
@@ -67,9 +67,9 @@ WSCLEAN_PREDICT_DOCS = DocstringTemplate("""
         Source polynomial type of shape :code:`(source,)`.
         If True, logarithmic polynomials are used.
         If False, standard polynomials are used.
-    ref_freq: $(array_type)
+    ref_freq : $(array_type)
         Source Reference frequency of shape :code:(`source,)`
-    frequency: $(array_type)
+    frequency : $(array_type)
         Frequency of shape :code:`(chan,)`
 
     Returns


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
