### PR TITLE
Update trove to latest master commit

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.1 (YYYY-MM-DD)
 ------------------
+* Update trove to latest master commit (:pr:`178`)
 * Added Cubic Spline support (:pr:`174`)
 * Depend on python-casacore >= 3.2.0 (:pr:`172`)
 * Drop Python 3.5 support and test Python 3.7 (:pr:`168`)

--- a/africanus/util/trove.py
+++ b/africanus/util/trove.py
@@ -19,7 +19,7 @@ from africanus.util.files import sha_hash_file
 
 _trove_dir = pjoin(include_dir, "trove")
 _trove_url = 'https://github.com/bryancatanzaro/trove/archive/master.zip'
-_trove_sha_hash = 'b4a0ac97f23fcc94064a75c5cab9464e4c65f136'
+_trove_sha_hash = '183c9ce229b3c0b2afeb808a9f4b07c9d9b9035d'
 _trove_version_str = 'Current release: v1.8.0 (02/16/2018)'
 _trove_version = "master"
 _trove_zip_dir = 'trove-' + _trove_version
@@ -78,7 +78,7 @@ def _install_trove():
                    'is %s and does not match the expected '
                    'hash of %s.') % (
                         _trove_download_filename, _trove_url,
-                        _trove_sha_hash, sha_hash)
+                        sha_hash, _trove_sha_hash)
 
             raise InstallTroveException(msg)
 


### PR DESCRIPTION
To take into account commit on master on Feb 8

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
