### PR TITLE
WSClean predict: Re-use flux variable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 * Added Cubic Spline support (:pr:`174`)
 * Depend on python-casacore >= 3.2.0 (:pr:`172`)
 * Drop Python 3.5 support and test Python 3.7 (:pr:`168`)
-* Implement optimised WSClean predict (:pr:`166`, :pr:`167`, :pr:`177`, :pr:`179`)
+* Implement optimised WSClean predict (:pr:`166`, :pr:`167`, :pr:`177`, :pr:`179`, :pr:`180`)
 * Simplify dask predict_vis code (:pr:`164`, :pr:`165`)
 * Document and check weight shapes in simple gridder and degridder
   (:pr:`162`, :pr:`163`)

--- a/africanus/model/wsclean/spec_model.py
+++ b/africanus/model/wsclean/spec_model.py
@@ -89,7 +89,7 @@ def spectra(I, coeffs, log_poly, ref_freq, frequency):
                         raise ValueError("Log polynomial flux must be > 0")
 
                     # Initialise with base polynomial value
-                    spectral_model[s, f] = np.log(I[s])
+                    spectral_model[s, f] = np.log(flux)
 
                     for c in range(ncoeffs):
                         term = coeffs[s, c]

--- a/africanus/rime/wsclean_predict.py
+++ b/africanus/rime/wsclean_predict.py
@@ -72,9 +72,9 @@ def wsclean_predict_impl(uvw, lm, source_type, gauss_shape,
                     im = np.sin(p) * spectrum[s, f]
 
                     # Calculate gaussian shape component and multiply in
-                    fu1 = u1*scaled_freq[f]
-                    fv1 = v1*scaled_freq[f]
-                    shape = np.exp(-(fu1*fu1 + fv1*fv1))
+                    fu1 = u1 * scaled_freq[f]
+                    fv1 = v1 * scaled_freq[f]
+                    shape = np.exp(-(fu1 * fu1 + fv1 * fv1))
                     re *= shape
                     im *= shape
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
