### PR TITLE
Use python-casacore wheels for travis testing

### DIFF
--- a/.travis/python36-all.docker
+++ b/.travis/python36-all.docker
@@ -3,7 +3,7 @@ FROM kernsuite/base:5
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils  python3.6 python3.6-dev 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-distutils  python3.6 python3.6-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.6 get-pip.py
 ADD . /code

--- a/.travis/python36-base.docker
+++ b/.travis/python36-base.docker
@@ -3,7 +3,7 @@ FROM kernsuite/base:5
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils  python3.6 python3.6-dev 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-distutils  python3.6 python3.6-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.6 get-pip.py
 ADD . /code

--- a/.travis/python37-all.docker
+++ b/.travis/python37-all.docker
@@ -3,7 +3,7 @@ FROM kernsuite/base:5
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils python3.7 python3.7-dev 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-distutils python3.7 python3.7-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.7 get-pip.py
 ADD . /code

--- a/.travis/python37-base.docker
+++ b/.travis/python37-base.docker
@@ -3,7 +3,7 @@ FROM kernsuite/base:5
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils  python3.7 python3.7-dev 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-distutils  python3.7 python3.7-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.7 get-pip.py
 ADD . /code

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.2 (2019-04-09)
 ------------------
 
+* Use python-casacore wheels for travis testing, instead of kernsuite packages (:pr:`185`)
 * Add a dask Estimating Progress Bar (:pr:`182`, :pr:`183`)
 
 0.2.1 (2019-04-03)

--- a/africanus/install/requirements.py
+++ b/africanus/install/requirements.py
@@ -27,8 +27,7 @@ extras_require = {
     'dask': ['dask[array] >= 1.1.0'],
     'jax': ['jax == 0.1.27', 'jaxlib == 0.1.14'],
     'scipy': ['scipy >= 1.0.0'],
-    'astropy': ['astropy >= 2.0.0, < 3.0; python_version <= "2.7"',
-                'astropy >= 3.0; python_version >= "3.0"'],
+    'astropy': ['astropy >= 3.0'],
     'python-casacore': ['python-casacore >= 3.2.0'],
     'testing': ['pytest', 'flaky', 'pytest-flake8']
 }


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
