### PR TITLE
Depend on pytest-flake8 >= 1.0.6

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.3 (YYYY-MM-DD)
 ------------------
+* Depend on pytest-flake8 >= 1.0.6 (:pr:`188`)
 * MeqTrees Comparison Script Updates (:pr:`160`)
 * Improve requirements and work around broken pytest-flake8 (:pr:`187`)
 * Use python-casacore wheels for travis testing, instead of kernsuite packages (:pr:`185`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,9 +4,9 @@ History
 
 0.2.3 (YYYY-MM-DD)
 ------------------
-* Depend on pytest-flake8 >= 1.0.6 (:pr:`188`)
+* Depend on pytest-flake8 >= 1.0.6 (:pr:`187`, :pr:`188`)
 * MeqTrees Comparison Script Updates (:pr:`160`)
-* Improve requirements and work around broken pytest-flake8 (:pr:`187`)
+* Improve requirements handling (:pr:`187`)
 * Use python-casacore wheels for travis testing, instead of kernsuite packages (:pr:`185`)
 
 

--- a/africanus/dft/kernels.py
+++ b/africanus/dft/kernels.py
@@ -146,7 +146,7 @@ im_to_vis_docs = _DFT_DOCSTRING(
 
     """,  # noqa
 
-    parameters="""
+    parameters=r"""
     Parameters
     ----------
 
@@ -194,7 +194,7 @@ vis_to_im_docs = _DFT_DOCSTRING(
 
     """,  # noqa
 
-    parameters="""
+    parameters=r"""
     Parameters
     ----------
 

--- a/africanus/gps/kernels.py
+++ b/africanus/gps/kernels.py
@@ -5,7 +5,7 @@ import numpy as np
 from africanus.gps.utils import abs_diff
 
 
-def exponential_squared(x, xp, sigmaf, l, pspec=False):
+def exponential_squared(x, xp, sigmaf, l, pspec=False):  # noqa: E741
     """
     Create exponential squared covariance
     function between :math:`D` dimensional

--- a/africanus/model/wsclean/spec_model.py
+++ b/africanus/model/wsclean/spec_model.py
@@ -6,7 +6,7 @@ from africanus.util.numba import generated_jit
 from africanus.util.docs import DocstringTemplate
 
 
-def ordinary_spectral_model(I, coeffs, log_poly, freq, ref_freq):
+def ordinary_spectral_model(I, coeffs, log_poly, freq, ref_freq):  # noqa: E741
     """ Numpy ordinary polynomial implementation """
     coeffs_idx = np.arange(1, coeffs.shape[1] + 1)
     # (source, chan, coeffs-comp)
@@ -16,10 +16,10 @@ def ordinary_spectral_model(I, coeffs, log_poly, freq, ref_freq):
     return I[:, None] + term.sum(axis=2)
 
 
-def log_spectral_model(I, coeffs, log_poly, freq, ref_freq):
+def log_spectral_model(I, coeffs, log_poly, freq, ref_freq):  # noqa: E741
     """ Numpy logarithmic polynomial implementation """
     # No negative flux
-    I = np.where(log_poly == False, 1.0, I)  # noqa
+    I = np.where(log_poly == False, 1.0, I)  # noqa: E741, E712
     coeffs_idx = np.arange(1, coeffs.shape[1] + 1)
     # (source, chan, coeffs-comp)
     term = np.log(freq[None, :, None] / ref_freq[:, None, None])
@@ -58,12 +58,12 @@ def _log_polynomial(log_poly, s):
 
 
 @generated_jit(nopython=True, nogil=True, cache=True)
-def spectra(I, coeffs, log_poly, ref_freq, frequency):
+def spectra(I, coeffs, log_poly, ref_freq, frequency):  # noqa: E741
     arg_dtypes = tuple(np.dtype(a.dtype.name) for a
                        in (I, coeffs, ref_freq, frequency))
     dtype = np.result_type(*arg_dtypes)
 
-    def impl(I, coeffs, log_poly, ref_freq, frequency):
+    def impl(I, coeffs, log_poly, ref_freq, frequency):  # noqa: E741
         if not (I.shape[0] == coeffs.shape[0] == ref_freq.shape[0]):
             raise ValueError("first dimensions of I, coeffs "
                              "and ref_freq don't match.")

--- a/africanus/rime/zernike.py
+++ b/africanus/rime/zernike.py
@@ -52,7 +52,7 @@ def zernike(j, rho, phi):
 
 
 @jit(nogil=True, nopython=True, cache=True)
-def _convert_coords(l, m):
+def _convert_coords(l, m):  # noqa: E741
     rho, phi = (l**2 + m ** 2) ** 0.5, np.arctan2(l, m)
     return rho, phi
 

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ extras_require = {
     'scipy': ['scipy >= 1.0.0'],
     'astropy': ['astropy >= 3.0'],
     'python-casacore': ['python-casacore >= 3.2.0'],
-    # TODO(sjperkins)
-    # Modify flake8 < 3.8.0 once
-    # https://github.com/tholo/pytest-flake8/issues/66 is fixed
-    'testing': ['pytest', 'flaky', 'pytest-flake8', 'flake8 < 3.8.0']
+    'testing': ['pytest', 'flaky', 'pytest-flake8 >= 1.0.6']
 }
 
 with open(str(Path("africanus", "install", "extras_require.py")), "w") as f:


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
