### PR TITLE
Fix incorrect SPI calculation and make predict defaults MeqTree equivalent.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,7 @@ Contributors
 
 * Landman Bester <lbester@ska.ac.za>
 * Benjamin Hugo <bhugo@ska.ac.za>
+* Jonathan Kenyon <jkenyon@ska.ac.za>
 * Gijs Molenaar <gijs@pythonic.nl>
 * Joshua van Staden <joshvstaden14@gmail.com>
 * Oleg Smirnov <oms@ska.ac.za, osmirnov@gmail.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 * MeqTrees Comparison Script Updates (:pr:`160`)
 * Improve requirements handling (:pr:`187`)
 * Use python-casacore wheels for travis testing, instead of kernsuite packages (:pr:`185`)
-
+* Fix incorrect SPI calculation and make predict defaults MeqTree equivalent (:pr:`189`)
 
 0.2.2 (2020-04-09)
 ------------------

--- a/africanus/model/spectral/spec_model.py
+++ b/africanus/model/spectral/spec_model.py
@@ -170,8 +170,8 @@ def spectral_model(stokes, spi, ref_freq, frequency, base=0):
                         spec_model = estokes[s, p]
 
                         for si in range(0, nspi):
-                            term = espi[s, si, p] * freq_ratio**(si + 1)
-                            spec_model += term
+                            term = (freq_ratio + 1) ** espi[s, si, p]
+                            spec_model *= term
 
                         spectral_model[s, f, p] = spec_model
 

--- a/africanus/model/spectral/spec_model.py
+++ b/africanus/model/spectral/spec_model.py
@@ -167,11 +167,11 @@ def spectral_model(stokes, spi, ref_freq, frequency, base=0):
                     rf = ref_freq[s]
 
                     for f in range(nchan):
-                        freq_ratio = (frequency[f] / rf) - 1.0
+                        freq_ratio = frequency[f] / rf
                         spec_model = estokes[s, p]
 
                         for si in range(0, nspi):
-                            term = (freq_ratio + 1) ** espi[s, si, p]
+                            term = freq_ratio ** espi[s, si, p]
                             spec_model *= term
 
                         spectral_model[s, f, p] = spec_model

--- a/africanus/model/spectral/spec_model.py
+++ b/africanus/model/spectral/spec_model.py
@@ -30,12 +30,13 @@ def numpy_spectral_model(stokes, spi, ref_freq, frequency, base):
     spectral_model = np.empty((stokes.shape[0], frequency.shape[0], npol),
                               dtype=stokes.dtype)
 
+    spectral_model[:, :, :] = stokes[:, None, :]
+
     for p, b in enumerate(base):
         if b in ("std", 0):
-            freq_ratio = (frequency[None, :] / ref_freq[:, None]) - 1.0
-            term = freq_ratio[:, None, :]**spi_exps[None, :, None]
-            term = spi[:, :, p, None] * term
-            spectral_model[:, :, p] = stokes[:, p, None] + term.sum(axis=1)
+            freq_ratio = (frequency[None, :] / ref_freq[:, None])
+            term = freq_ratio[:, None, :]**spi[:, :, p, None]
+            spectral_model[:, :, p] *= term.prod(axis=1)
         elif b in ("log", 1):
             freq_ratio = np.log(frequency[None, :] / ref_freq[:, None])
             term = freq_ratio[:, None, :]**spi_exps[None, :, None]

--- a/africanus/rime/examples/predict.py
+++ b/africanus/rime/examples/predict.py
@@ -280,10 +280,10 @@ def parse_sky_model(filename, chunks):
         try:
             # Extract SPI for I.
             # Zero Q, U and V to get 1 on the exponential
-            spi = [[spectrum.spi, 0, 0, 0]]
+            spi = [[spectrum.spi]*4]
         except AttributeError:
             # Default I SPI to -0.7
-            spi = [[-0.7, 0, 0, 0]]
+            spi = [[0, 0, 0, 0]]
 
         if typecode == "gau":
             emaj = source.shape.ex
@@ -462,7 +462,7 @@ def vis_factory(args, source_type, sky_model,
                             source.spi,
                             source.ref_freq,
                             frequency,
-                            base=[1, 0, 0, 0])
+                            base=0)
 
     brightness = convert(stokes, ["I", "Q", "U", "V"],
                          corr_schema(pol))


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```