### PR TITLE
Fix spectral model docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Fix spectral model documentation (:pr:`190`), to match changes in (:pr:`189`)
+
 0.2.3 (2020-05-14)
 ------------------
 * Fix incorrect SPI calculation and make predict defaults MeqTree equivalent (:pr:`189`)

--- a/africanus/model/spectral/spec_model.py
+++ b/africanus/model/spectral/spec_model.py
@@ -220,8 +220,7 @@ Compute a spectral model, per polarisation.
     :nowrap:
 
     \begin{eqnarray}
-    I(\lambda) & = & \sum_{i=0} \alpha_{i} (\lambda / \lambda_0 - 1)^i
-      \, \textrm{where} \, \alpha_0 = I(\lambda_0) \\
+    I(\lambda) & = & I_0 \prod_{i=1} (\lambda / \lambda_0 - 1)^{\alpha_{i}} \\
     \ln( I(\lambda) ) & = & \sum_{i=0} \alpha_{i}
       \ln (\lambda / \lambda_0)^i
       \, \textrm{where} \, \alpha_0 = \ln I_0 \\

--- a/africanus/model/spectral/spec_model.py
+++ b/africanus/model/spectral/spec_model.py
@@ -220,7 +220,7 @@ Compute a spectral model, per polarisation.
     :nowrap:
 
     \begin{eqnarray}
-    I(\lambda) & = & I_0 \prod_{i=1} (\lambda / \lambda_0 - 1)^{\alpha_{i}} \\
+    I(\lambda) & = & I_0 \prod_{i=1} (\lambda / \lambda_0)^{\alpha_{i}} \\
     \ln( I(\lambda) ) & = & \sum_{i=0} \alpha_{i}
       \ln (\lambda / \lambda_0)^i
       \, \textrm{where} \, \alpha_0 = \ln I_0 \\


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
