### PR TITLE
Don't separate lm_max into l and m

### DIFF
--- a/africanus/averaging/tests/test_bda_mapping.py
+++ b/africanus/averaging/tests/test_bda_mapping.py
@@ -213,10 +213,8 @@ def test_bda_binner(time, ants, interval, phase_dir,
     flag_row = np.zeros(time.shape[0], dtype=np.int8)
 
     decorrelation = 0.95
-    l = 0.5  # noqa: E741
-    m = 0.5
-    n = np.sqrt(1.0 - l**2 - m**2) - 1.0
-    binner = Binner(0, 0, l, m, n, ref_freq, decorrelation)
+    lm_max = 0.5  # noqa: E741
+    binner = Binner(0, 0, lm_max, ref_freq, decorrelation)
     binner.start_bin(0, time, interval, flag_row)
     binner.add_row(1, auto_corrs, time, interval, uvw, flag_row)
     binner.add_row(2, auto_corrs, time, interval, uvw, flag_row)


### PR DESCRIPTION
- [ x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
