### PR TITLE
Optimise detaper dft kernels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.6 (YYYY-MM-DD)
 ------------------
-* Add Perley Polyhedron Faceting Gridder/Degridder (:pr:`202`)
+* Add Perley Polyhedron Faceting Gridder/Degridder (:pr:`202`, :pr:`215`)
 
 
 0.2.5 (2020-07-01)

--- a/africanus/gridding/perleypolyhedron/kernels.py
+++ b/africanus/gridding/perleypolyhedron/kernels.py
@@ -9,10 +9,11 @@ except ImportError as e:
 else:
     scipy_import_error = None
 
-from africanus.util.numba import jit
+from africanus.util.numba import jit, register_jitable
 from africanus.util.requirements import requires_optional
 
 
+@register_jitable
 def uspace(W, oversample):
     """
     Generates a kernel sampling of the form
@@ -128,6 +129,7 @@ def compute_detaper(npix, K, W, oversample=5):
     return np.abs(fk)
 
 
+@jit(nopython=True, nogil=True, fastmath=True, cache=True)
 def compute_detaper_dft(npix, K, W, oversample=5):
     """
     Computes detapering function of a oversampled kernel
@@ -137,24 +139,22 @@ def compute_detaper_dft(npix, K, W, oversample=5):
     """
     pk = np.zeros((npix, npix), dtype=np.complex128)
     ksample = uspace(W, oversample=oversample)
+    rK = K.ravel()
 
-    @jit(nopython=True, nogil=True, fastmath=True, parallel=True)
-    def __absdft(npix, K, W, oversample, pk, ksample):
-        for p in prange(npix * npix):
-            ll = p % npix
-            mm = p // npix
-            llN = (ll - npix // 2) / float(npix)
-            mmN = (mm - npix // 2) / float(npix)
-            for x in range(K.size):
-                xx = ksample[x % K.shape[1]]
-                yy = ksample[x // K.shape[1]]
-                pk[mm, ll] += K.flatten()[x] * np.exp(-2.0j * np.pi *
-                                                      (llN * xx + mmN * yy))
-        return np.abs(pk)
-
-    return __absdft(npix, K, W, oversample, pk, ksample)
+    for p in prange(npix * npix):
+        ll = p % npix
+        mm = p // npix
+        llN = (ll - npix // 2) / float(npix)
+        mmN = (mm - npix // 2) / float(npix)
+        for x in range(K.size):
+            xx = ksample[x % K.shape[1]]
+            yy = ksample[x // K.shape[1]]
+            pk[mm, ll] += rK[x] * np.exp(-2.0j * np.pi *
+                                         (llN * xx + mmN * yy))
+    return np.abs(pk)
 
 
+@jit(nopython=True, nogil=True, fastmath=True, cache=True)
 def compute_detaper_dft_seperable(npix, K, W, oversample=5):
     """
     Computes detapering function of a oversampled seperable kernel
@@ -167,15 +167,12 @@ def compute_detaper_dft_seperable(npix, K, W, oversample=5):
     """
     pkX = np.zeros((npix), dtype=np.complex128)
     ksample = uspace(W, oversample=oversample)
+    rK = K.ravel()
 
-    @jit(nopython=True, nogil=True, fastmath=True)
-    def __dft1d(npix, K, W, oversample, pk, ksample):
-        for ll in range(npix):
-            llN = (ll - npix // 2) / float(npix)
-            for x in range(K.size):
-                xx = ksample[x]
-                pk[ll] += K.flatten()[x] * np.exp(-2.0j * np.pi * (llN * xx))
-        return pk
+    for ll in range(npix):
+        llN = (ll - npix // 2) / float(npix)
+        for x in range(K.size):
+            xx = ksample[x]
+            pkX[ll] += rK[x] * np.exp(-2.0j * np.pi * (llN * xx))
 
-    fpkX = __dft1d(npix, K, W, oversample, pkX, ksample)
-    return np.abs(np.outer(fpkX, fpkX))
+    return np.abs(np.outer(pkX, pkX))

--- a/africanus/util/numba.py
+++ b/africanus/util/numba.py
@@ -22,10 +22,12 @@ if on_rtd():
     jit = _fake_decorator
     njit = _fake_decorator
     stencil = _fake_decorator
+
     overload = _fake_decorator
+    register_jitable = _fake_decorator
 else:
     from numba import cfunc, jit, njit, generated_jit, stencil  # noqa
-    from numba.extending import overload  # noqa
+    from numba.extending import overload, register_jitable  # noqa
 
 
 def is_numba_type_none(arg):


### PR DESCRIPTION
- [x] Tests added / passed
  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
