### PR TITLE
Correct Irregular Grid Nesting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.6 (YYYY-MM-DD)
 ------------------
+* Correct Irregular Grid nesting in BeamAxes (:pr:`217`)
 * Add Perley Polyhedron Faceting Gridder/Degridder (:pr:`202`)
 
 

--- a/africanus/util/beams.py
+++ b/africanus/util/beams.py
@@ -72,7 +72,7 @@ class BeamAxes(FitsAxes):
         # Currently only implemented for FREQ dimension.
         irregular_grid = [np.asarray(
                     [header.get('G%s%d' % (self._ctype[i], j), None)
-                    for j in range(1, self._naxis[i]+1)])
+                     for j in range(1, self._naxis[i]+1)])
                 for i in range(self._ndims)]
 
         # Irregular grids are only valid if values exist for all grid points

--- a/africanus/util/beams.py
+++ b/africanus/util/beams.py
@@ -70,10 +70,10 @@ class BeamAxes(FitsAxes):
         super(BeamAxes, self).__init__(header)
         # Check for custom irregular grid format.
         # Currently only implemented for FREQ dimension.
-        irregular_grid = np.asarray([
-            [header.get('G%s%d' % (self._ctype[i], j), None)
-             for j in range(1, self._naxis[i]+1)]
-            for i in range(self._ndims)])
+        irregular_grid = [np.asarray(
+                    [header.get('G%s%d' % (self._ctype[i], j), None)
+                    for j in range(1, self._naxis[i]+1)])
+                for i in range(self._ndims)]
 
         # Irregular grids are only valid if values exist for all grid points
         self._irreg = [all(x is not None for x in irregular_grid[i])
@@ -95,7 +95,7 @@ class BeamAxes(FitsAxes):
 
             # Set up the grid
             self._grid[i] = (_regular_grid(i) if not self._irreg[i]
-                             else np.asarray(irregular_grid[i]))
+                             else irregular_grid[i])
 
     @property
     def ndims(self):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
