### PR TITLE
Time and channel bda - minor fixes

### DIFF
--- a/africanus/averaging/bda_mapping.py
+++ b/africanus/averaging/bda_mapping.py
@@ -284,30 +284,43 @@ class Binner(object):
             # In this case frequency phase difference
             # just becomes the decorrelation factor
 
-            u_sel = uvw[rs: re + 1, 0]
-            v_sel = uvw[rs: re + 1, 1]
-            w_sel = uvw[rs: re + 1, 2]
+            # u_sel = uvw[rs: re + 1, 0]
+            # v_sel = uvw[rs: re + 1, 1]
+            # w_sel = uvw[rs: re + 1, 2]
 
-            uv_dist = (np.sqrt(u_sel**2 + v_sel**2)*self.max_lm +
-                       np.abs(w_sel)*self.n_max)
+            # uv_dist = (np.sqrt(u_sel**2 + v_sel**2)*self.max_lm +
+            #            np.abs(w_sel)*self.n_max)
 
-            delta_nu = (lightspeed / (2*np.pi)) * self.decorrelation / uv_dist
+            delta_nu = (lightspeed / (2*np.pi)) * \
+                       (self.decorrelation / max_abs_dist)
+
+            # print(delta_nu, self.max_lm, self.n_max)
 
             # half_𝞓𝞍 = (self.decorrelation if rs == re else
             #             self.decorrelation / self.bin_half_Δψ)
             # max_𝞓𝝼 = (half_𝞓𝞍 / np.pi) * (lightspeed / max_abs_dist)
             # nchan = max(int(1), int(chan_width.sum() / max_𝞓𝝼))
 
+            # print("dnu", delta_nu)
+
             fracsizeChanBlock = delta_nu / chan_width
+
+            # print(fracsizeChanBlock)
 
             fracsizeChanBlockMin = max(fracsizeChanBlock.min(), 1)
 
             nchan = np.ceil(chan_width.size/fracsizeChanBlockMin)
 
+            # print(rs, re, nchan)
+
             # Now find the next highest integer factorisation
             # of the input number of channels
             s = np.searchsorted(nchan_factors, nchan, side='left')
             nchan = nchan_factors[min(nchan_factors.shape[0] - 1, s)]
+
+            # if rs!=re:
+            #     print(rs, re, nchan)
+
 
         # Finalise bin values for return
         out = FinaliseOutput(self.tbin,

--- a/africanus/averaging/bda_mapping.py
+++ b/africanus/averaging/bda_mapping.py
@@ -283,10 +283,26 @@ class Binner(object):
             # we can't meaningfully calculate baseline speed.
             # In this case frequency phase difference
             # just becomes the decorrelation factor
-            half_𝞓𝞍 = (self.decorrelation if rs == re else
-                        self.decorrelation / self.bin_half_Δψ)
-            max_𝞓𝝼 = (half_𝞓𝞍 / np.pi) * (lightspeed / max_abs_dist)
-            nchan = max(int(1), int(chan_width.sum() / max_𝞓𝝼))
+
+            u_sel = uvw[rs: re + 1, 0]
+            v_sel = uvw[rs: re + 1, 1]
+            w_sel = uvw[rs: re + 1, 2]
+
+            uv_dist = (np.sqrt(u_sel**2 + v_sel**2)*self.max_lm +
+                       np.abs(w_sel)*self.n_max)
+
+            delta_nu = (lightspeed / (2*np.pi)) * self.decorrelation / uv_dist
+
+            # half_𝞓𝞍 = (self.decorrelation if rs == re else
+            #             self.decorrelation / self.bin_half_Δψ)
+            # max_𝞓𝝼 = (half_𝞓𝞍 / np.pi) * (lightspeed / max_abs_dist)
+            # nchan = max(int(1), int(chan_width.sum() / max_𝞓𝝼))
+
+            fracsizeChanBlock = delta_nu / chan_width
+
+            fracsizeChanBlockMin = max(fracsizeChanBlock.min(), 1)
+
+            nchan = np.ceil(chan_width.size/fracsizeChanBlockMin)
 
             # Now find the next highest integer factorisation
             # of the input number of channels

--- a/africanus/averaging/bda_mapping.py
+++ b/africanus/averaging/bda_mapping.py
@@ -219,14 +219,13 @@ class Binner(object):
         # that ||(l,m)||=l_max, n_max=|sqrt(1-l_max^2)-1|;
         # the max phase change will be ||(du,dv)||*l_max+|dw|*n_max
         duvw = np.sqrt(du**2 + dv**2)
-        half_𝞓𝞇 = (np.pi * self.max_chan_freq *
-                   (duvw * self.max_lm + np.abs(dw) * self.n_max) /
-                   lightspeed)
+        half_𝞓𝞇 = (2 * np.pi * (self.max_chan_freq/lightspeed) *
+                   (duvw * self.max_lm + np.abs(dw) * self.n_max))
 
         # Do not add the row to the bin as it
         # would exceed the decorrelation tolerance
         # or the required number of seconds in the bin
-        if (half_𝞓𝞇 <= self.decorrelation) or (dt > self.time_bin_secs):
+        if (half_𝞓𝞇 >= self.decorrelation) or (dt > self.time_bin_secs):
             return False
 
         # Add the row by making it the end of the bin

--- a/africanus/averaging/bda_mapping.py
+++ b/africanus/averaging/bda_mapping.py
@@ -284,43 +284,22 @@ class Binner(object):
             # In this case frequency phase difference
             # just becomes the decorrelation factor
 
-            # u_sel = uvw[rs: re + 1, 0]
-            # v_sel = uvw[rs: re + 1, 1]
-            # w_sel = uvw[rs: re + 1, 2]
-
-            # uv_dist = (np.sqrt(u_sel**2 + v_sel**2)*self.max_lm +
-            #            np.abs(w_sel)*self.n_max)
+            # The following is copied from DDFacet. Variables names could
+            # be changed but wanted to keep the correspondence clear.
 
             delta_nu = (lightspeed / (2*np.pi)) * \
                        (self.decorrelation / max_abs_dist)
 
-            # print(delta_nu, self.max_lm, self.n_max)
-
-            # half_𝞓𝞍 = (self.decorrelation if rs == re else
-            #             self.decorrelation / self.bin_half_Δψ)
-            # max_𝞓𝝼 = (half_𝞓𝞍 / np.pi) * (lightspeed / max_abs_dist)
-            # nchan = max(int(1), int(chan_width.sum() / max_𝞓𝝼))
-
-            # print("dnu", delta_nu)
-
             fracsizeChanBlock = delta_nu / chan_width
-
-            # print(fracsizeChanBlock)
 
             fracsizeChanBlockMin = max(fracsizeChanBlock.min(), 1)
 
             nchan = np.ceil(chan_width.size/fracsizeChanBlockMin)
 
-            # print(rs, re, nchan)
-
             # Now find the next highest integer factorisation
             # of the input number of channels
             s = np.searchsorted(nchan_factors, nchan, side='left')
             nchan = nchan_factors[min(nchan_factors.shape[0] - 1, s)]
-
-            # if rs!=re:
-            #     print(rs, re, nchan)
-
 
         # Finalise bin values for return
         out = FinaliseOutput(self.tbin,


### PR DESCRIPTION
- [ ] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
