### PR TITLE
Specify epsilon for the wgridder manually

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.2.9 (????-??-??)
+------------------
+* Fix manually specifying wgridder precision (:pr:`230`) 
+
 0.2.8 (2020-10-08)
 ------------------
 * Fix NoneType issue in wgridder when weights are None (:pr:`228`)

--- a/africanus/gridding/wgridder/dask.py
+++ b/africanus/gridding/wgridder/dask.py
@@ -28,19 +28,10 @@ def _model_wrapper(uvw, freq, model, freq_bin_idx, freq_bin_counts, cell,
 
 @requires_optional('dask.array', dask_import_error)
 def model(uvw, freq, image, freq_bin_idx, freq_bin_counts, cell,
-          weights=None, flag=None, celly=None, epsilon=None, nthreads=1,
+          weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
           do_wstacking=True):
     # determine output type
     complex_type = da.result_type(image, np.complex64)
-
-    # set precision
-    if epsilon is None:
-        if image.dtype == np.float64:
-            epsilon = 1e-7
-        elif image.dtype == np.float32:
-            epsilon = 1e-5
-        else:
-            raise ValueError("image of incorrect type")
 
     if celly is None:
         celly = cell
@@ -89,19 +80,14 @@ def _dirty_wrapper(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny,
 
 @requires_optional('dask.array', dask_import_error)
 def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
-          weights=None, flag=None, celly=None, epsilon=None, nthreads=1,
+          weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
           do_wstacking=True):
 
-    # set precision
-    if epsilon is None:
-        if vis.dtype == np.complex128:
-            epsilon = 1e-7
-            real_type = np.float64
-        elif vis.dtype == np.complex64:
-            epsilon = 1e-5
-            real_type = np.float64
-        else:
-            raise ValueError("vis of incorrect type")
+    # get real data type (not available from inputs)
+    if vis.dtype == np.complex128:
+        real_type = np.float64
+    elif vis.dtype == np.complex64:
+        real_type = np.float32
 
     if celly is None:
         celly = cell
@@ -155,18 +141,9 @@ def _residual_wrapper(uvw, freq, model, vis, freq_bin_idx, freq_bin_counts,
 
 @requires_optional('dask.array', dask_import_error)
 def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
-             weights=None, flag=None, celly=None, epsilon=None,
+             weights=None, flag=None, celly=None, epsilon=1e-5,
              nthreads=1, do_wstacking=True):
-
-    # set precision
-    if epsilon is None:
-        if image.dtype == np.float64:
-            epsilon = 1e-7
-        elif image.dtype == np.float32:
-            epsilon = 1e-5
-        else:
-            raise ValueError("image of incorrect type")
-
+    
     if celly is None:
         celly = cell
 

--- a/africanus/gridding/wgridder/dask.py
+++ b/africanus/gridding/wgridder/dask.py
@@ -143,7 +143,7 @@ def _residual_wrapper(uvw, freq, model, vis, freq_bin_idx, freq_bin_counts,
 def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
              weights=None, flag=None, celly=None, epsilon=1e-5,
              nthreads=1, do_wstacking=True):
-    
+
     if celly is None:
         celly = cell
 

--- a/africanus/gridding/wgridder/im2residim.py
+++ b/africanus/gridding/wgridder/im2residim.py
@@ -53,16 +53,8 @@ def _residual_internal(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts,
 # to chunk over row
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
-             weights=None, flag=None, celly=None, epsilon=None, nthreads=1,
+             weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
              do_wstacking=True):
-    # set precision
-    if epsilon is None:
-        if image.dtype == np.float64:
-            epsilon = 1e-7
-        elif image.dtype == np.float32:
-            epsilon = 1e-5
-        else:
-            raise ValueError("Model of incorrect type")
 
     if celly is None:
         celly = cell

--- a/africanus/gridding/wgridder/im2vis.py
+++ b/africanus/gridding/wgridder/im2vis.py
@@ -41,15 +41,7 @@ def _model_internal(uvw, freq, image, freq_bin_idx, freq_bin_counts, cell,
 
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def model(uvw, freq, image, freq_bin_idx, freq_bin_counts, cell, weights=None,
-          flag=None, celly=None, epsilon=None, nthreads=1, do_wstacking=True):
-    # set precision
-    if epsilon is None:
-        if image.dtype == np.float64:
-            epsilon = 1e-7
-        elif image.dtype == np.float32:
-            epsilon = 1e-5
-        else:
-            raise ValueError("Model of incorrect type")
+          flag=None, celly=None, epsilon=1e-5, nthreads=1, do_wstacking=True):
 
     if celly is None:
         celly = cell

--- a/africanus/gridding/wgridder/tests/test_wgridder.py
+++ b/africanus/gridding/wgridder/tests/test_wgridder.py
@@ -46,9 +46,10 @@ def explicit_gridder(uvw, freq, ms, wgt, nxdirty, nydirty, xpixsize, ypixsize,
 @pmp("nchan", (1, 7))
 @pmp("nband", (1, 3))
 @pmp("precision", ('single', 'double'))
+@pmp("epsilon", (1e-3, 1e-4))
 @pmp("nthreads", (1, 6))
 def test_gridder(nx, ny, fov, nrow, nchan, nband,
-                 precision, nthreads):
+                 precision, epsilon, nthreads):
     # run comparison against dft with a frequency mapping imposed
     if nband > nchan:
         return
@@ -60,7 +61,6 @@ def test_gridder(nx, ny, fov, nrow, nchan, nband,
         real_type = "f8"
         complex_type = "c16"
 
-    epsilon = 1e-5
     np.random.seed(420)
     cell = fov*np.pi/180/nx
     f0 = 1e9

--- a/africanus/gridding/wgridder/tests/test_wgridder.py
+++ b/africanus/gridding/wgridder/tests/test_wgridder.py
@@ -56,11 +56,11 @@ def test_gridder(nx, ny, fov, nrow, nchan, nband,
     if precision == 'single':
         real_type = "f4"
         complex_type = "c8"
-        epsilon = 1e-4
     else:
         real_type = "f8"
         complex_type = "c16"
-        epsilon = 1e-7
+        
+    epsilon = 1e-5
     np.random.seed(420)
     cell = fov*np.pi/180/nx
     f0 = 1e9
@@ -224,11 +224,11 @@ def test_dask_dirty(nx, ny, fov, nrow, nchan, nband,
     if precision == 'single':
         real_type = np.float32
         complex_type = np.complex64
-        decimal = 4  # does not pass at 5
+        decimal = 4  # sometimes fails at 5
     else:
         real_type = np.float64
         complex_type = np.complex128
-        decimal = 7
+        decimal = 5
     cell = fov*np.pi/180/nx
     f0 = 1e9
     freq = (f0 + np.arange(nchan)*(f0/nchan))
@@ -288,11 +288,11 @@ def test_dask_model(nx, ny, fov, nrow, nchan, nband,
     if precision == 'single':
         real_type = np.float32
         complex_type = np.complex64
-        decimal = 4  # does not pass at 5
+        decimal = 4  # sometimes fails at 5
     else:
         real_type = np.float64
         complex_type = np.complex128
-        decimal = 7
+        decimal = 5
     cell = fov*np.pi/180/nx
     f0 = 1e9
     freq = (f0 + np.arange(nchan)*(f0/nchan))
@@ -355,11 +355,11 @@ def test_dask_residual(nx, ny, fov, nrow, nchan, nband,
     if precision == 'single':
         real_type = np.float32
         complex_type = np.complex64
-        decimal = 4  # does not pass at 5
+        decimal = 4  # sometimes fails at 5
     else:
         real_type = np.float64
         complex_type = np.complex128
-        decimal = 7
+        decimal = 5
     cell = fov*np.pi/180/nx
     f0 = 1e9
     freq = (f0 + np.arange(nchan)*(f0/nchan))

--- a/africanus/gridding/wgridder/tests/test_wgridder.py
+++ b/africanus/gridding/wgridder/tests/test_wgridder.py
@@ -59,7 +59,7 @@ def test_gridder(nx, ny, fov, nrow, nchan, nband,
     else:
         real_type = "f8"
         complex_type = "c16"
-        
+
     epsilon = 1e-5
     np.random.seed(420)
     cell = fov*np.pi/180/nx

--- a/africanus/gridding/wgridder/vis2im.py
+++ b/africanus/gridding/wgridder/vis2im.py
@@ -51,16 +51,8 @@ def _dirty_internal(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny,
 # to chunk over row
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
-          weights=None, flag=None, celly=None, epsilon=None, nthreads=1,
+          weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
           do_wstacking=True):
-    # set precision
-    if epsilon is None:
-        if vis.dtype == np.complex128:
-            epsilon = 1e-7
-        elif vis.dtype == np.complex64:
-            epsilon = 1e-5
-        else:
-            raise ValueError("vis of incorrect type")
 
     if celly is None:
         celly = cell


### PR DESCRIPTION
There was a bug in wgridder.dirty which caused the gridder to crash if an epsilon other than the default was used. This should now be fixed. I have also changed the default to 1e-5 regardless of whether single or double precision griding is required.