### PR TITLE
Add mindet to avoid div0 errors in spi fitter and fix alpha and I0 variance estimates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 
 0.2.10 (YYYY-MM-DD)
 -------------------
-*
+* Add mindet to avoid div0 errors in spi fitter and fix alpha and I0 variance
+  estimates (:pr:`234`)
 
 0.2.9 (2020-12-15)
 ------------------

--- a/africanus/model/spi/component_spi.py
+++ b/africanus/model/spi/component_spi.py
@@ -10,7 +10,7 @@ from africanus.util.numba import jit
 
 @jit(nopython=True, nogil=True, cache=True)
 def _fit_spi_components_impl(data, weights, freqs, freq0, out,
-                             jac, ncomps, nfreqs, tol, maxiter):
+                             jac, ncomps, nfreqs, tol, maxiter, mindet):
     w = freqs/freq0
     for comp in range(ncomps):
         eps = 1.0
@@ -37,7 +37,7 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
                 hess00 += jac[0, v] * weights[v] * jac[0, v]
                 hess01 += jac[0, v] * weights[v] * jac[1, v]
                 hess11 += jac[1, v] * weights[v] * jac[1, v]
-            det = hess00 * hess11 - hess01**2
+            det = np.maximum(hess00 * hess11 - hess01**2, mindet)
             alphak = alphap + (hess11 * jr0 - hess01 * jr1)/det
             i0k = i0p + (-hess01 * jr0 + hess00 * jr1)/det
             eps = np.maximum(np.abs(alphak - alphap), np.abs(i0k - i0p))
@@ -67,8 +67,15 @@ def fit_spi_components(data, weights, freqs, freq0,
         tmp = np.abs(freqs - freq0)
         ref_freq_idx = np.argwhere(tmp == tmp.min()).squeeze()
         out[2, :] = data[:, ref_freq_idx]
+    if data.dtype == np.float64:
+        mindet = 1e-12
+    elif data.dtype == np.float32:
+        mindet = 1e-5
+    else:
+        raise ValueError("Unsupported data type. Must be float32 of float64.")
+
     return _fit_spi_components_impl(data, weights, freqs, freq0, out,
-                                    jac, ncomps, nfreqs, tol, maxiter)
+                                    jac, ncomps, nfreqs, tol, maxiter, mindet)
 
 
 SPI_DOCSTRING = DocstringTemplate(

--- a/africanus/model/spi/component_spi.py
+++ b/africanus/model/spi/component_spi.py
@@ -31,7 +31,7 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
             jr0 = 0.0
             jr1 = 0.0
             for v in range(nfreqs):
-                lik += residual[v] * weights[v] * residual[v]
+                lik += residual[v] * weights[v] * residual[v]/2
                 jr0 += jac[0, v] * weights[v] * residual[v]
                 jr1 += jac[1, v] * weights[v] * residual[v]
                 hess00 += jac[0, v] * weights[v] * jac[0, v]
@@ -45,9 +45,9 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
         if k == maxiter:
             print("Warning - max iterations exceeded for component ", comp)
         out[0, comp] = alphak
-        out[1, comp] = hess11/det
+        out[1, comp] = np.sqrt(hess11/det * lik/2)
         out[2, comp] = i0k
-        out[3, comp] = hess00/det
+        out[3, comp] = np.sqrt(hess00/det * lik/2)
     return out
 
 

--- a/africanus/model/spi/component_spi.py
+++ b/africanus/model/spi/component_spi.py
@@ -12,6 +12,7 @@ from africanus.util.numba import jit
 def _fit_spi_components_impl(data, weights, freqs, freq0, out,
                              jac, ncomps, nfreqs, tol, maxiter, mindet):
     w = freqs/freq0
+    dof = w.size - 2
     for comp in range(ncomps):
         eps = 1.0
         k = 0
@@ -31,7 +32,7 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
             jr0 = 0.0
             jr1 = 0.0
             for v in range(nfreqs):
-                lik += residual[v] * weights[v] * residual[v]/2
+                lik += residual[v] * weights[v] * residual[v]  # /2
                 jr0 += jac[0, v] * weights[v] * residual[v]
                 jr1 += jac[1, v] * weights[v] * residual[v]
                 hess00 += jac[0, v] * weights[v] * jac[0, v]
@@ -45,9 +46,9 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
         if k == maxiter:
             print("Warning - max iterations exceeded for component ", comp)
         out[0, comp] = alphak
-        out[1, comp] = np.sqrt(hess11/det * lik/2)
+        out[1, comp] = hess11/det * lik/dof
         out[2, comp] = i0k
-        out[3, comp] = np.sqrt(hess00/det * lik/2)
+        out[3, comp] = hess00/det * lik/dof
     return out
 
 

--- a/africanus/model/spi/component_spi.py
+++ b/africanus/model/spi/component_spi.py
@@ -32,7 +32,7 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
             jr0 = 0.0
             jr1 = 0.0
             for v in range(nfreqs):
-                lik += residual[v] * weights[v] * residual[v]  # /2
+                lik += residual[v] * weights[v] * residual[v]
                 jr0 += jac[0, v] * weights[v] * residual[v]
                 jr1 += jac[1, v] * weights[v] * residual[v]
                 hess00 += jac[0, v] * weights[v] * jac[0, v]

--- a/africanus/model/spi/tests/test_component_spi.py
+++ b/africanus/model/spi/tests/test_component_spi.py
@@ -17,7 +17,7 @@ def test_fit_spi_components_vs_scipy():
 
     np.random.seed(123)
 
-    ncomps = 25
+    ncomps = 250
     alphas = -0.7 + 0.25 * np.random.randn(ncomps, 1)
     i0s = 5.0 + np.random.randn(ncomps, 1)
     nfreqs = 100
@@ -42,18 +42,17 @@ def test_fit_spi_components_vs_scipy():
     for i in range(ncomps):
         popt, pcov = curve_fit(spi_func, (freqs / freq0).squeeze(), data[i, :],
                                sigma=np.diag(sigma**2),
-                               p0=np.array([1.0, -0.7]))
+                               p0=np.array([1.0, -0.7]),
+                               absolute_sigma=False)
         I02[i] = popt[0]
         I0var2[i] = pcov[0, 0]
         alpha2[i] = popt[1]
         alphavar2[i] = pcov[1, 1]
 
     np.testing.assert_array_almost_equal(alpha1, alpha2, decimal=6)
-    # note variances not necessarily accurate to within tol because
-    # scipy uses LM instead of GN
-    np.testing.assert_array_almost_equal(alphavar1, alphavar2, decimal=3)
+    np.testing.assert_array_almost_equal(alphavar1, alphavar2, decimal=6)
     np.testing.assert_array_almost_equal(I01, I02, decimal=6)
-    np.testing.assert_array_almost_equal(I0var1, I0var2, decimal=3)
+    np.testing.assert_array_almost_equal(I0var1, I0var2, decimal=6)
 
 
 def test_dask_fit_spi_components_vs_np():


### PR DESCRIPTION
Small fix to avoid divide by zero errors during spi fitting. Let's hold off merging for now, want to test this thoroughly first