### PR TITLE
Upgrade to ducc0 0.8.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,11 +4,11 @@ History
 
 0.2.10 (YYYY-MM-DD)
 -------------------
-*
+* Upgrade ducc0 to version 0.8.0 (:pr:`236`)
 
 0.2.9 (2020-12-15)
 ------------------
-* Upgrade ducc0 to version 0.7 (:pr:`233`)
+* Upgrade ducc0 to version 0.7.0 (:pr:`233`)
 * Fix manually specifying wgridder precision (:pr:`230`)
 
 0.2.8 (2020-10-08)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
     'scipy': ['scipy >= 1.4.0'],
     'astropy': ['astropy >= 3.0'],
     'python-casacore': ['python-casacore >= 3.3.1'],
-    'ducc0': ['ducc0 >= 0.7.0'],
+    'ducc0': ['ducc0 >= 0.8.0'],
     'testing': ['pytest', 'flaky', 'pytest-flake8 >= 1.0.6']
 }
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
