### PR TITLE
Add hessian function and double accumulation option to gridder

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.10 (YYYY-MM-DD)
 -------------------
+* Add double accumulation option and Hessian function to wgridder (:pr:`237`)
 * Upgrade ducc0 to version 0.8.0 (:pr:`236`)
 * Add mindet to avoid div0 errors in spi fitter and fix alpha and I0 variance
   estimates (:pr:`234`)

--- a/africanus/gridding/wgridder/__init__.py
+++ b/africanus/gridding/wgridder/__init__.py
@@ -3,3 +3,4 @@
 from africanus.gridding.wgridder.im2vis import model
 from africanus.gridding.wgridder.vis2im import dirty
 from africanus.gridding.wgridder.im2residim import residual
+from africanus.gridding.wgridder.hessian import hessian

--- a/africanus/gridding/wgridder/dask.py
+++ b/africanus/gridding/wgridder/dask.py
@@ -11,10 +11,13 @@ import numpy as np
 from africanus.gridding.wgridder.vis2im import DIRTY_DOCS
 from africanus.gridding.wgridder.im2vis import MODEL_DOCS
 from africanus.gridding.wgridder.im2residim import RESIDUAL_DOCS
+from africanus.gridding.wgridder.hessian import HESSIAN_DOCS
 from africanus.gridding.wgridder.im2vis import _model_internal as model_np
 from africanus.gridding.wgridder.vis2im import _dirty_internal as dirty_np
 from africanus.gridding.wgridder.im2residim import (_residual_internal
                                                     as residual_np)
+from africanus.gridding.wgridder.hessian import (_hessian_internal
+                                                 as hessian_np)
 from africanus.util.requirements import requires_optional
 
 
@@ -71,17 +74,17 @@ def model(uvw, freq, image, freq_bin_idx, freq_bin_counts, cell,
 
 def _dirty_wrapper(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny,
                    cell, weights, flag, celly, epsilon, nthreads,
-                   do_wstacking):
+                   do_wstacking, double_accum):
 
     return dirty_np(uvw[0], freq, vis, freq_bin_idx, freq_bin_counts,
                     nx, ny, cell, weights, flag, celly, epsilon,
-                    nthreads, do_wstacking)
+                    nthreads, do_wstacking, double_accum)
 
 
 @requires_optional('dask.array', dask_import_error)
 def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
           weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
-          do_wstacking=True):
+          do_wstacking=True, double_accum=False):
 
     # get real data type (not available from inputs)
     if vis.dtype == np.complex128:
@@ -121,6 +124,7 @@ def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
                        epsilon, None,
                        nthreads, None,
                        do_wstacking, None,
+                       double_accum, None,
                        adjust_chunks={'chan': freq_bin_idx.chunks[0],
                                       'row': (1,)*len(vis.chunks[0])},
                        new_axes={"nx": nx, "ny": ny},
@@ -132,17 +136,17 @@ def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
 
 def _residual_wrapper(uvw, freq, model, vis, freq_bin_idx, freq_bin_counts,
                       cell, weights, flag, celly, epsilon, nthreads,
-                      do_wstacking):
+                      do_wstacking, double_accum):
 
     return residual_np(uvw[0], freq, model, vis, freq_bin_idx,
                        freq_bin_counts, cell, weights, flag, celly, epsilon,
-                       nthreads, do_wstacking)
+                       nthreads, do_wstacking, double_accum)
 
 
 @requires_optional('dask.array', dask_import_error)
 def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
              weights=None, flag=None, celly=None, epsilon=1e-5,
-             nthreads=1, do_wstacking=True):
+             nthreads=1, do_wstacking=True, double_accum=False):
 
     if celly is None:
         celly = cell
@@ -175,8 +179,61 @@ def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
                        epsilon, None,
                        nthreads, None,
                        do_wstacking, None,
+                       double_accum, None,
                        adjust_chunks={'chan': freq_bin_idx.chunks[0],
                                       'row': (1,)*len(vis.chunks[0])},
+                       dtype=image.dtype,
+                       align_arrays=False)
+    return img.sum(axis=0)
+
+
+def _hessian_wrapper(uvw, freq, model, freq_bin_idx, freq_bin_counts,
+                     cell, weights, flag, celly, epsilon, nthreads,
+                     do_wstacking, double_accum):
+
+    return hessian_np(uvw[0], freq, model, freq_bin_idx,
+                      freq_bin_counts, cell, weights, flag, celly, epsilon,
+                      nthreads, do_wstacking, double_accum)
+
+
+@requires_optional('dask.array', dask_import_error)
+def hessian(uvw, freq, image, freq_bin_idx, freq_bin_counts, cell,
+            weights=None, flag=None, celly=None, epsilon=1e-5,
+            nthreads=1, do_wstacking=True, double_accum=False):
+
+    if celly is None:
+        celly = cell
+
+    if not nthreads:
+        import multiprocessing
+        nthreads = multiprocessing.cpu_count()
+
+    if weights is None:
+        weight_out = None
+    else:
+        weight_out = ('row', 'chan')
+
+    if flag is None:
+        flag_out = None
+    else:
+        flag_out = ('row', 'chan')
+
+    img = da.blockwise(_hessian_wrapper, ('row', 'chan', 'nx', 'ny'),
+                       uvw, ('row', 'three'),
+                       freq, ('chan',),
+                       image, ('chan', 'nx', 'ny'),
+                       freq_bin_idx, ('chan',),
+                       freq_bin_counts, ('chan',),
+                       cell, None,
+                       weights, weight_out,
+                       flag, flag_out,
+                       celly, None,
+                       epsilon, None,
+                       nthreads, None,
+                       do_wstacking, None,
+                       double_accum, None,
+                       adjust_chunks={'chan': freq_bin_idx.chunks[0],
+                                      'row': (1,)*len(uvw.chunks[0])},
                        dtype=image.dtype,
                        align_arrays=False)
     return img.sum(axis=0)
@@ -187,4 +244,6 @@ model.__doc__ = MODEL_DOCS.substitute(
 dirty.__doc__ = DIRTY_DOCS.substitute(
                     array_type=":class:`dask.array.Array`")
 residual.__doc__ = RESIDUAL_DOCS.substitute(
+                     array_type=":class:`dask.array.Array`")
+hessian.__doc__ = HESSIAN_DOCS.substitute(
                      array_type=":class:`dask.array.Array`")

--- a/africanus/gridding/wgridder/hessian.py
+++ b/africanus/gridding/wgridder/hessian.py
@@ -39,8 +39,7 @@ def _hessian_internal(uvw, freq, image, freq_bin_idx, freq_bin_counts,
                             pixsize_x=cell, pixsize_y=celly,
                             nu=0, nv=0, epsilon=epsilon,
                             nthreads=nthreads, mask=mask,
-                            do_wstacking=do_wstacking,
-                            double_precision_accumulation=double_accum)
+                            do_wstacking=do_wstacking)
         convolvedim[0, i] = ms2dirty(
                                 uvw=uvw, freq=freq[ind], ms=modelvis,
                                 wgt=wgt, npix_x=nx, npix_y=ny,

--- a/africanus/gridding/wgridder/hessian.py
+++ b/africanus/gridding/wgridder/hessian.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+
+try:
+    from ducc0.wgridder import dirty2ms, ms2dirty
+except ImportError as e:
+    ducc_import_error = e
+else:
+    ducc_import_error = None
+
+import numpy as np
+from africanus.util.docs import DocstringTemplate
+from africanus.util.requirements import requires_optional
+
+
+@requires_optional('ducc0.wgridder', ducc_import_error)
+def _hessian_internal(uvw, freq, image, freq_bin_idx, freq_bin_counts,
+                      cell, weights, flag, celly, epsilon, nthreads,
+                      do_wstacking, double_accum):
+
+    # adjust for chunking
+    # need a copy here if using multiple row chunks
+    freq_bin_idx2 = freq_bin_idx - freq_bin_idx.min()
+    nband = freq_bin_idx.size
+    _, nx, ny = image.shape
+    # the extra dimension is required to allow for chunking over row
+    convolvedim = np.zeros((1, nband, nx, ny), dtype=image.dtype)
+    for i in range(nband):
+        ind = slice(freq_bin_idx2[i], freq_bin_idx2[i] + freq_bin_counts[i])
+        if weights is not None:
+            wgt = weights[:, ind]
+        else:
+            wgt = None
+        if flag is not None:
+            mask = flag[:, ind]
+        else:
+            mask = None
+        modelvis = dirty2ms(uvw=uvw, freq=freq[ind],
+                            dirty=image[i], wgt=None,
+                            pixsize_x=cell, pixsize_y=celly,
+                            nu=0, nv=0, epsilon=epsilon,
+                            nthreads=nthreads, mask=mask,
+                            do_wstacking=do_wstacking,
+                            double_precision_accumulation=double_accum)
+        convolvedim[0, i] = ms2dirty(
+                                uvw=uvw, freq=freq[ind], ms=modelvis,
+                                wgt=wgt, npix_x=nx, npix_y=ny,
+                                pixsize_x=cell, pixsize_y=celly,
+                                nu=0, nv=0, epsilon=epsilon,
+                                nthreads=nthreads, mask=mask,
+                                do_wstacking=do_wstacking,
+                                double_precision_accumulation=double_accum)
+    return convolvedim
+
+
+# This additional wrapper is required to allow the dask wrappers
+# to chunk over row
+@requires_optional('ducc0.wgridder', ducc_import_error)
+def hessian(uvw, freq, image, freq_bin_idx, freq_bin_counts, cell,
+            weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
+            do_wstacking=True, double_accum=False):
+
+    if celly is None:
+        celly = cell
+
+    if not nthreads:
+        import multiprocessing
+        nthreads = multiprocessing.cpu_count()
+
+    residim = _hessian_internal(uvw, freq, image, freq_bin_idx,
+                                freq_bin_counts, cell, weights, flag,
+                                celly, epsilon, nthreads, do_wstacking,
+                                double_accum)
+    return residim[0]
+
+
+HESSIAN_DOCS = DocstringTemplate(
+    r"""
+    Compute action of Hessian on an image using ducc
+
+    .. math::
+
+
+        R^\dagger \Sigma^{-1} R x
+
+    where :math:`R` is an implicit degridding operator and
+    :math:`x` is the image of shape :code:`(band, nx, ny)`.
+
+    The number of imaging bands :code:`(band)` must
+    be less than or equal to the number of channels
+    :code:`(chan)` at which the data were obtained.
+    The mapping from :code:`(chan)` to :code:`(band)` is described
+    by :code:`freq_bin_idx` and :code:`freq_bin_counts` as
+    described below.
+
+
+    Parameters
+    ----------
+    uvw : $(array_type)
+        uvw coordinates at which visibilities were
+        obtained with shape :code:`(row, 3)`.
+    freq : $(array_type)
+        Observational frequencies of shape :code:`(chan,)`.
+    model : $(array_type)
+        Model image to degrid of shape :code:`(band, nx, ny)`.
+    weights : $(array_type)
+        Imaging weights of shape :code:`(row, chan)`.
+    freq_bin_idx : $(array_type)
+        Starting indices of frequency bins for each imaging
+        band of shape :code:`(band,)`.
+    freq_bin_counts : $(array_type)
+        The number of channels in each imaging band of shape :code:`(band,)`.
+    cell : float
+        The cell size of a pixel along the :math:`x` direction in radians.
+    flag: $(array_type), optional
+        Flags of shape :code:`(row,chan)`. Will only process visibilities
+        for which flag!=0
+    celly : float, optional
+        The cell size of a pixel along the :math:`y` direction in radians.
+        By default same as cell size along :math:`x` direction.
+    nu : int, optional
+        The number of pixels in the padded grid along the :math:`x` direction.
+        Chosen automatically by default.
+    nv : int, optional
+        The number of pixels in the padded grid along the :math:`y` direction.
+        Chosen automatically by default.
+    epsilon : float, optional
+        The precision of the gridder with respect to the direct Fourier
+        transform. By deafult, this is set to :code:`1e-5` for single
+        precision and :code:`1e-7` for double precision.
+    nthreads : int, optional
+        The number of threads to use. Defaults to one.
+    do_wstacking : bool, optional
+        Whether to correct for the w-term or not. Defaults to True
+    double_accum : bool, optional
+        If true ducc will accumulate in double precision regardless of
+        the input type.
+
+    Returns
+    -------
+    residual : $(array_type)
+        Residual image corresponding to :code:`model` of shape
+        :code:`(band, nx, ny)`.
+    """)
+
+try:
+    hessian.__doc__ = HESSIAN_DOCS.substitute(
+                        array_type=":class:`numpy.ndarray`")
+except AttributeError:
+    pass

--- a/africanus/gridding/wgridder/im2residim.py
+++ b/africanus/gridding/wgridder/im2residim.py
@@ -15,7 +15,7 @@ from africanus.util.requirements import requires_optional
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def _residual_internal(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts,
                        cell, weights, flag, celly, epsilon, nthreads,
-                       do_wstacking):
+                       do_wstacking, double_accum):
 
     # adjust for chunking
     # need a copy here if using multiple row chunks
@@ -34,18 +34,21 @@ def _residual_internal(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts,
             mask = flag[:, ind]
         else:
             mask = None
-        residvis = vis[:, ind] - dirty2ms(uvw=uvw, freq=freq[ind],
-                                          dirty=image[i], wgt=None,
-                                          pixsize_x=cell, pixsize_y=celly,
-                                          nu=0, nv=0, epsilon=epsilon,
-                                          nthreads=nthreads, mask=mask,
-                                          do_wstacking=do_wstacking)
+        tvis = vis[:, ind]
+        residvis = tvis - dirty2ms(
+                                uvw=uvw, freq=freq[ind],
+                                dirty=image[i], wgt=None,
+                                pixsize_x=cell, pixsize_y=celly,
+                                nu=0, nv=0, epsilon=epsilon,
+                                nthreads=nthreads, mask=mask,
+                                do_wstacking=do_wstacking)
         residim[0, i] = ms2dirty(uvw=uvw, freq=freq[ind], ms=residvis,
                                  wgt=wgt, npix_x=nx, npix_y=ny,
                                  pixsize_x=cell, pixsize_y=celly,
                                  nu=0, nv=0, epsilon=epsilon,
                                  nthreads=nthreads, mask=mask,
-                                 do_wstacking=do_wstacking)
+                                 do_wstacking=do_wstacking,
+                                 double_precision_accumulation=double_accum)
     return residim
 
 
@@ -54,7 +57,7 @@ def _residual_internal(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts,
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
              weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
-             do_wstacking=True):
+             do_wstacking=True, double_accum=False):
 
     if celly is None:
         celly = cell
@@ -65,7 +68,8 @@ def residual(uvw, freq, image, vis, freq_bin_idx, freq_bin_counts, cell,
 
     residim = _residual_internal(uvw, freq, image, vis, freq_bin_idx,
                                  freq_bin_counts, cell, weights, flag,
-                                 celly, epsilon, nthreads, do_wstacking)
+                                 celly, epsilon, nthreads, do_wstacking,
+                                 double_accum)
     return residim[0]
 
 
@@ -144,6 +148,9 @@ RESIDUAL_DOCS = DocstringTemplate(
         The number of threads to use. Defaults to one.
     do_wstacking : bool, optional
         Whether to correct for the w-term or not. Defaults to True
+    double_accum : bool, optional
+        If true ducc will accumulate in double precision regardless of
+        the input type.
 
     Returns
     -------

--- a/africanus/gridding/wgridder/tests/test_wgridder.py
+++ b/africanus/gridding/wgridder/tests/test_wgridder.py
@@ -206,6 +206,72 @@ def test_residual(nx, ny, fov, nrow, nchan, nband,
         residim1/rmax, residim2/rmax, decimal=decimal)
 
 
+@pmp("nx", (128, ))
+@pmp("ny", (256,))
+@pmp("fov", (0.5,))
+@pmp("nrow", (10000000,))
+@pmp("nchan", (2,))
+@pmp("nband", (2,))
+@pmp("precision", ('single',))
+@pmp("nthreads", (4,))
+def test_hessian(nx, ny, fov, nrow, nchan, nband,
+                 precision, nthreads):
+    # Compare the result of dirty computed with Hessian
+    #   ID = hessian(x)
+    # to that computed using dirty.
+    from africanus.gridding.wgridder import dirty, hessian
+    np.random.seed(420)
+    if precision == 'single':
+        real_type = np.float32
+        complex_type = np.complex64
+        atol = 1e-5
+    else:
+        real_type = np.float64
+        complex_type = np.complex128
+        atol = 1e-5
+
+    uvw = 1000*np.random.randn(nrow, 3)
+    uvw[:, 2] = 0
+    u_max = np.abs(uvw[:, 0]).max()
+    v_max = np.abs(uvw[:, 1]).max()
+    uv_max = np.maximum(u_max, v_max)
+
+    f0 = 1e9
+    freq = (f0 + np.arange(nchan)*(f0/nchan))
+
+    cell_N = 0.1/(2*uv_max*freq.max()/lightspeed)
+    cell = cell_N/2.0  # super_resolution_factor of 2
+
+    vis = np.ones((nrow, nchan), dtype=complex_type)
+
+    step = nchan//nband
+    if step:
+        freq_bin_idx = np.arange(0, nchan, step)
+        freq_mapping = np.append(freq_bin_idx, nchan)
+        freq_bin_counts = freq_mapping[1::] - freq_mapping[0:-1]
+    else:
+        freq_bin_idx = np.array([0], dtype=np.int8)
+        freq_bin_counts = np.array([1], dtype=np.int8)
+    nband = freq_bin_idx.size
+    model_im = np.zeros((nband, nx, ny), dtype=real_type)
+    model_im[:, nx//2, ny//2] = 1.0
+
+    dirty_im1 = dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts,
+                      nx, ny, cell, nthreads=nthreads, do_wstacking=False,
+                      double_accum=True)
+
+    # test accumulation
+    assert_allclose(dirty_im1.max()/nrow, 1.0, rtol=atol)
+
+    dirty_im2 = hessian(uvw, freq, model_im, freq_bin_idx,
+                        freq_bin_counts, cell, nthreads=nthreads,
+                        do_wstacking=False, double_accum=True)
+
+    # rtol not reliable since there will be values close to zero in the
+    # dirty images
+    assert_allclose(dirty_im1/nrow, dirty_im2/nrow, atol=atol, rtol=1e-2)
+
+
 @pmp("nx", (30, 250))
 @pmp("ny", (128,))
 @pmp("fov", (5.0,))
@@ -401,3 +467,64 @@ def test_dask_residual(nx, ny, fov, nrow, nchan, nband,
     rmax = np.maximum(np.abs(residim_np).max(), np.abs(residim_da).max())
     assert_array_almost_equal(
         residim_np/rmax, residim_da/rmax, decimal=decimal)
+
+
+@pmp("nx", (64,))
+@pmp("ny", (128,))
+@pmp("fov", (5.0,))
+@pmp("nrow", (3333, 10000))
+@pmp("nchan", (4,))
+@pmp("nband", (2,))
+@pmp("precision", ('single', 'double'))
+@pmp("nthreads", (1,))
+@pmp("nchunks", (1, 3))
+def test_dask_hessian(nx, ny, fov, nrow, nchan, nband,
+                      precision, nthreads, nchunks):
+    da = pytest.importorskip("dask.array")
+    from africanus.gridding.wgridder import hessian as hessian_np
+    from africanus.gridding.wgridder.dask import hessian
+    np.random.seed(420)
+    if precision == 'single':
+        real_type = np.float32
+        decimal = 4  # sometimes fails at 5
+    else:
+        real_type = np.float64
+        decimal = 5
+    cell = fov*np.pi/180/nx
+    f0 = 1e9
+    freq = (f0 + np.arange(nchan)*(f0/nchan))
+    uvw = ((np.random.rand(nrow, 3)-0.5) /
+           (cell*freq[-1]/lightspeed))
+    wgt = np.random.rand(nrow, nchan).astype(real_type)
+    step = np.maximum(1, nchan//nband)
+    if step:
+        freq_bin_idx = np.arange(0, nchan, step)
+        freq_mapping = np.append(freq_bin_idx, nchan)
+        freq_bin_counts = freq_mapping[1::] - freq_mapping[0:-1]
+    else:
+        freq_bin_idx = np.array([0], dtype=np.int8)
+        freq_bin_counts = np.array([1], dtype=np.int8)
+    nband = freq_bin_idx.size
+    image = np.random.randn(nband, nx, ny).astype(real_type)
+    convim_np = hessian_np(uvw, freq, image, freq_bin_idx,
+                           freq_bin_counts, cell, weights=wgt,
+                           nthreads=nthreads)
+
+    rows_per_task = int(np.ceil(nrow/nchunks))
+    row_chunks = (nchunks-1) * (rows_per_task,)
+    row_chunks += (nrow - np.sum(row_chunks),)
+    freq_da = da.from_array(freq, chunks=step)
+    uvw_da = da.from_array(uvw, chunks=(row_chunks, -1))
+    image_da = da.from_array(image, chunks=(1, nx, ny))
+    wgt_da = da.from_array(wgt, chunks=(row_chunks, step))
+    freq_bin_idx_da = da.from_array(freq_bin_idx, chunks=1)
+    freq_bin_counts_da = da.from_array(freq_bin_counts, chunks=1)
+
+    convim_da = hessian(uvw_da, freq_da, image_da,
+                        freq_bin_idx_da, freq_bin_counts_da,
+                        cell, weights=wgt_da, nthreads=nthreads).compute()
+
+    # should agree to within epsilon
+    rmax = np.maximum(np.abs(convim_np).max(), np.abs(convim_da).max())
+    assert_array_almost_equal(
+        convim_np/rmax, convim_da/rmax, decimal=decimal)

--- a/africanus/gridding/wgridder/vis2im.py
+++ b/africanus/gridding/wgridder/vis2im.py
@@ -15,7 +15,7 @@ from africanus.util.requirements import requires_optional
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def _dirty_internal(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny,
                     cell, weights, flag, celly, epsilon, nthreads,
-                    do_wstacking):
+                    do_wstacking, double_accum):
     # adjust for chunking
     # need a copy here if using multiple row chunks
     freq_bin_idx2 = freq_bin_idx - freq_bin_idx.min()
@@ -43,7 +43,8 @@ def _dirty_internal(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny,
                                pixsize_x=cell, pixsize_y=celly,
                                nu=0, nv=0, epsilon=epsilon,
                                nthreads=nthreads, mask=mask,
-                               do_wstacking=do_wstacking)
+                               do_wstacking=do_wstacking,
+                               double_precision_accumulation=double_accum)
     return dirty
 
 
@@ -52,7 +53,7 @@ def _dirty_internal(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny,
 @requires_optional('ducc0.wgridder', ducc_import_error)
 def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
           weights=None, flag=None, celly=None, epsilon=1e-5, nthreads=1,
-          do_wstacking=True):
+          do_wstacking=True, double_accum=False):
 
     if celly is None:
         celly = cell
@@ -63,7 +64,7 @@ def dirty(uvw, freq, vis, freq_bin_idx, freq_bin_counts, nx, ny, cell,
 
     dirty = _dirty_internal(uvw, freq, vis, freq_bin_idx, freq_bin_counts,
                             nx, ny, cell, weights, flag, celly,
-                            epsilon, nthreads, do_wstacking)
+                            epsilon, nthreads, do_wstacking, double_accum)
     return dirty[0]
 
 
@@ -126,6 +127,9 @@ DIRTY_DOCS = DocstringTemplate(
         If set to zero will use all available cores.
     do_wstacking : bool, optional
         Whether to correct for the w-term or not. Defaults to True
+    double_accum : bool, optional
+        If true ducc will accumulate in double precision regardless of
+        the input type.
 
     Returns
     -------

--- a/docs/gridding-api.rst
+++ b/docs/gridding-api.rst
@@ -46,10 +46,12 @@ Numpy
     dirty
     model
     residual
+    hessian
 
 .. autofunction:: dirty
 .. autofunction:: model
 .. autofunction:: residual
+.. autofunction:: hessian
 
 Dask
 ++++
@@ -60,10 +62,12 @@ Dask
     dirty
     model
     residual
+    hessian
 
 .. autofunction:: dirty
 .. autofunction:: model
 .. autofunction:: residual
+.. autofunction:: hessian
 
 Utilities
 ~~~~~~~~~


### PR DESCRIPTION
* adds a paranoid mode to the gridder to avoid accumulation errors when gridding in single precision. 
* adds the Hessian function (out of memory and in place) R.H W R to wgridder. 