### PR TITLE
Set dof in spi fitter to min of 1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.10 (YYYY-MM-DD)
 -------------------
+* Don't let dof go to zero during spi fitting (:pr:`240`)
 * Add support for Shapelets and Zernike Polynomials (:pr:`231`)
 * Add beam model during SPI fitting (:pr:`238`)
 * Add double accumulation option and Hessian function to wgridder (:pr:`237`)

--- a/africanus/model/spi/component_spi.py
+++ b/africanus/model/spi/component_spi.py
@@ -13,7 +13,7 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out,
                              jac, beam, ncomps, nfreqs,
                              tol, maxiter, mindet):
     w = freqs/freq0
-    dof = w.size - 2
+    dof = np.maximum(w.size - 2, 1)
     for comp in range(ncomps):
         eps = 1.0
         k = 0


### PR DESCRIPTION
As reported here

https://github.com/ratt-ru/pfb-clean/issues/40

we need to make sure that the effective dof during spi fitting does not go to zero. 