### PR TITLE
Upgrade to CuPy 9.0 and fix template encoding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.11 (YYYY-MM-DD)
 -------------------
+* Fix CuPy imports and template encoding (:pr:`251`)
 * Parse and zero spectral models containing 'nan' and 'inf' in wsclean model files (:pr:`250`)
 * Deprecate Python 3.6 support, add Python 3.9 support (:pr:`248`)
 * Clarify _wrapper names (:pr:`247`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.11 (YYYY-MM-DD)
 -------------------
-* Fix CuPy imports and template encoding (:pr:`251`)
+* Upgrade to CuPy 9.0 and fix template encoding (:pr:`251`)
 * Parse and zero spectral models containing 'nan' and 'inf' in wsclean model files (:pr:`250`)
 * Deprecate Python 3.6 support, add Python 3.9 support (:pr:`248`)
 * Clarify _wrapper names (:pr:`247`)

--- a/africanus/model/coherency/cuda/conversion.py
+++ b/africanus/model/coherency/cuda/conversion.py
@@ -176,7 +176,7 @@ def _generate_kernel(inputs, input_schema, output_schema):
                   input_type=cuda_type(inputs.dtype),
                   output_type=cuda_type(out_dtype),
                   assign_exprs=assign_exprs,
-                  elements=in_elems).encode("utf-8")
+                  elements=in_elems)
 
     # cuda block, flatten non-schema dims into a single source dim
     blockdimx = 512

--- a/africanus/rime/cuda/beam.py
+++ b/africanus/rime/cuda/beam.py
@@ -15,7 +15,7 @@ from africanus.util.requirements import requires_optional
 
 try:
     import cupy as cp
-    from cupy.core._scalar import get_typename as _get_typename
+    from cupy._core._scalar import get_typename as _get_typename
     from cupy.cuda.compiler import CompileException
 except ImportError as e:
     opt_import_error = e
@@ -49,7 +49,6 @@ def _generate_interp_kernel(beam_freq_map, frequencies):
                   beam_freq_type=_get_typename(beam_freq_map.dtype),
                   freq_type=_get_typename(frequencies.dtype))
 
-    code = code.encode('utf-8')
     dtype = np.result_type(beam_freq_map, frequencies)
 
     return cp.RawKernel(code, name), block, dtype
@@ -134,8 +133,6 @@ def _generate_main_kernel(beam, beam_lm_ext, beam_freq_map,
                   freq_type=_get_typename(frequencies.dtype),
                   dde_type=_get_typename(beam.real.dtype),
                   dde_dims=dde_dims)
-
-    code = code.encode('utf-8')
 
     # Complex output type
     return cp.RawKernel(code, name), block, dtype

--- a/africanus/rime/cuda/feeds.py
+++ b/africanus/rime/cuda/feeds.py
@@ -14,7 +14,7 @@ from africanus.util.requirements import requires_optional
 
 try:
     import cupy as cp
-    from cupy.core._scalar import get_typename as _get_typename
+    from cupy._core._scalar import get_typename as _get_typename
     from cupy.cuda.compiler import CompileException
 except ImportError as e:
     opt_import_error = e
@@ -53,8 +53,6 @@ def _generate_kernel(parallactic_angles, feed_type):
                   sincos_fn=cuda_function('sincos', dtype),
                   pa_type=_get_typename(dtype),
                   out_type=_get_typename(dtype))
-
-    code = code.encode('utf-8')
 
     # Complex output type
     out_dtype = np.result_type(dtype, np.complex64)

--- a/africanus/rime/cuda/phase.py
+++ b/africanus/rime/cuda/phase.py
@@ -15,7 +15,7 @@ from africanus.util.requirements import requires_optional
 
 try:
     import cupy as cp
-    from cupy.core._scalar import get_typename as _get_typename
+    from cupy._core._scalar import get_typename as _get_typename
     from cupy.cuda.compiler import CompileException
 except ImportError:
     pass
@@ -53,7 +53,7 @@ def _generate_kernel(lm, uvw, frequency):
                   sincos_fn=cuda_function('sincos', out_dtype),
                   minus_two_pi_over_c=minus_two_pi_over_c,
                   blockdimx=blockdimx,
-                  blockdimy=blockdimy).encode('utf-8')
+                  blockdimy=blockdimy)
 
     # Complex output type
     out_dtype = np.result_type(out_dtype, np.complex64)

--- a/africanus/rime/cuda/predict.py
+++ b/africanus/rime/cuda/predict.py
@@ -96,7 +96,7 @@ def _generate_kernel(time_index, antenna1, antenna2,
                   out_type=cuda_type(out_dtype),
                   corrs=ncorrs,
                   out_ndim=out_ndim,
-                  warp_size=32).encode('utf-8')
+                  warp_size=32)
 
     return cp.RawKernel(code, name), block, out_dtype
 

--- a/africanus/rime/cuda/test_shuffle.py
+++ b/africanus/rime/cuda/test_shuffle.py
@@ -118,7 +118,7 @@ def test_cuda_shuffle_transpose():
     }
 
     code = _TEMPLATE.render(type=dtypes[dtype], warp_size=32,
-                            corrs=ncorrs, debug="false").encode("utf-8")
+                            corrs=ncorrs, debug="false")
     kernel = cp.RawKernel(code, "kernel")
 
     inputs = cp.arange(nvis*ncorrs, dtype=dtype).reshape(nvis, ncorrs)
@@ -345,7 +345,7 @@ def test_cuda_shuffle_transpose_2(ncorrs):
                             register_assign_cycles=register_assign_cycles,
                             warp_size=32,
                             corrs=ncorrs,
-                            debug="false").encode("utf-8")
+                            debug="false")
     kernel = cp.RawKernel(code, "kernel")
 
     inputs = cp.arange(nvis*ncorrs, dtype=dtype).reshape(nvis, ncorrs)

--- a/africanus/rime/cuda/tests/test_macros.py
+++ b/africanus/rime/cuda/tests/test_macros.py
@@ -30,7 +30,7 @@ def test_cuda_inplace_warp_transpose(ncorrs, dtype, nvis, debug):
     }
 
     code = render(type=dtypes[dtype], warp_size=32,
-                  corrs=ncorrs, debug=debug).encode("utf-8")
+                  corrs=ncorrs, debug=debug)
     kernel = cp.RawKernel(code, "kernel")
 
     inputs = cp.arange(nvis*ncorrs, dtype=dtype).reshape(nvis, ncorrs)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if not on_rtd:
     ]
 
 extras_require = {
-    "cuda": ["cupy >= 5.0.0", "jinja2 >= 2.10"],
+    "cuda": ["cupy >= 9.0.0", "jinja2 >= 2.10"],
     "dask": ["dask[array] >= 2.2.0"],
     "jax": ["jax >= 0.2.11", "jaxlib >= 0.1.65"],
     "scipy": ["scipy >= 1.4.0"],


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
