### PR TITLE
Disallow numba 0.54.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.11 (YYYY-MM-DD)
 -------------------
+* Disallow numba 0.54.0 (:pr:`254`)
 * Upgrade to CuPy 9.0 and fix template encoding (:pr:`251`)
 * Parse and zero spectral models containing 'nan' and 'inf' in wsclean model files (:pr:`250`)
 * Deprecate Python 3.6 support, add Python 3.9 support (:pr:`248`)

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -90,15 +90,15 @@ def jones_mul_factory(have_ddes, have_coh, jones_type, accumulate):
 
     if have_coh and have_ddes:
         if jones_type == JONES_1_OR_2:
-            def jones_mul(a1j, blj, a2j, out):
-                for c in range(out.shape[0]):
+            def jones_mul(a1j, blj, a2j, jones_out):
+                for c in range(jones_out.shape[0]):
                     if accumulate:
-                        out[c] += a1j[c] * blj[c] * np.conj(a2j[c])
+                        jones_out[c] += a1j[c] * blj[c] * np.conj(a2j[c])
                     else:
-                        out[c] = a1j[c] * blj[c] * np.conj(a2j[c])
+                        jones_out[c] = a1j[c] * blj[c] * np.conj(a2j[c])
 
         elif jones_type == JONES_2X2:
-            def jones_mul(a1j, blj, a2j, out):
+            def jones_mul(a1j, blj, a2j, jones_out):
                 a2_xx_H = np.conj(a2j[0, 0])
                 a2_xy_H = np.conj(a2j[0, 1])
                 a2_yx_H = np.conj(a2j[1, 0])
@@ -110,71 +110,71 @@ def jones_mul_factory(have_ddes, have_coh, jones_type, accumulate):
                 yy = blj[1, 0] * a2_yx_H + blj[1, 1] * a2_yy_H
 
                 if accumulate:
-                    out[0, 0] += a1j[0, 0] * xx + a1j[0, 1] * yx
-                    out[0, 1] += a1j[0, 0] * xy + a1j[0, 1] * yy
-                    out[1, 0] += a1j[1, 0] * xx + a1j[1, 1] * yx
-                    out[1, 1] += a1j[1, 0] * xy + a1j[1, 1] * yy
+                    jones_out[0, 0] += a1j[0, 0] * xx + a1j[0, 1] * yx
+                    jones_out[0, 1] += a1j[0, 0] * xy + a1j[0, 1] * yy
+                    jones_out[1, 0] += a1j[1, 0] * xx + a1j[1, 1] * yx
+                    jones_out[1, 1] += a1j[1, 0] * xy + a1j[1, 1] * yy
                 else:
-                    out[0, 0] = a1j[0, 0] * xx + a1j[0, 1] * yx
-                    out[0, 1] = a1j[0, 0] * xy + a1j[0, 1] * yy
-                    out[1, 0] = a1j[1, 0] * xx + a1j[1, 1] * yx
-                    out[1, 1] = a1j[1, 0] * xy + a1j[1, 1] * yy
+                    jones_out[0, 0] = a1j[0, 0] * xx + a1j[0, 1] * yx
+                    jones_out[0, 1] = a1j[0, 0] * xy + a1j[0, 1] * yy
+                    jones_out[1, 0] = a1j[1, 0] * xx + a1j[1, 1] * yx
+                    jones_out[1, 1] = a1j[1, 0] * xy + a1j[1, 1] * yy
 
         else:
             raise ex
     elif have_ddes and not have_coh:
         if jones_type == JONES_1_OR_2:
-            def jones_mul(a1j, a2j, out):
-                for c in range(out.shape[0]):
+            def jones_mul(a1j, a2j, jones_out):
+                for c in range(jones_out.shape[0]):
                     if accumulate:
-                        out[c] += a1j[c] * np.conj(a2j[c])
+                        jones_out[c] += a1j[c] * np.conj(a2j[c])
                     else:
-                        out[c] = a1j[c] * np.conj(a2j[c])
+                        jones_out[c] = a1j[c] * np.conj(a2j[c])
 
         elif jones_type == JONES_2X2:
-            def jones_mul(a1j, a2j, out):
+            def jones_mul(a1j, a2j, jones_out):
                 a2_xx_H = np.conj(a2j[0, 0])
                 a2_xy_H = np.conj(a2j[0, 1])
                 a2_yx_H = np.conj(a2j[1, 0])
                 a2_yy_H = np.conj(a2j[1, 1])
 
                 if accumulate:
-                    out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
-                    out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
-                    out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
-                    out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
+                    jones_out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
+                    jones_out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
+                    jones_out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
+                    jones_out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
                 else:
-                    out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
-                    out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
-                    out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
-                    out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
+                    jones_out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
+                    jones_out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
+                    jones_out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
+                    jones_out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
         else:
             raise ex
     elif not have_ddes and have_coh:
         if jones_type == JONES_1_OR_2:
-            def jones_mul(blj, out):
-                for c in range(out.shape[0]):
+            def jones_mul(blj, jones_out):
+                for c in range(jones_out.shape[0]):
                     if accumulate:
-                        out[c] += blj[c]
-                    elif id(blj) == id(out):
+                        jones_out[c] += blj[c]
+                    elif id(blj) == id(jones_out):
                         pass
                     else:
-                        out[c] = blj[c]
+                        jones_out[c] = blj[c]
 
         elif jones_type == JONES_2X2:
-            def jones_mul(blj, out):
+            def jones_mul(blj, jones_out):
                 if accumulate:
-                    out[0, 0] += blj[0, 0]
-                    out[0, 1] += blj[0, 1]
-                    out[1, 0] += blj[1, 0]
-                    out[1, 1] += blj[1, 1]
-                elif id(blj) == id(out):
+                    jones_out[0, 0] += blj[0, 0]
+                    jones_out[0, 1] += blj[0, 1]
+                    jones_out[1, 0] += blj[1, 0]
+                    jones_out[1, 1] += blj[1, 1]
+                elif id(blj) == id(jones_out):
                     pass
                 else:
-                    out[0, 0] = blj[0, 0]
-                    out[0, 1] = blj[0, 1]
-                    out[1, 0] = blj[1, 0]
-                    out[1, 1] = blj[1, 1]
+                    jones_out[0, 0] = blj[0, 0]
+                    jones_out[0, 1] = blj[0, 1]
+                    jones_out[1, 0] = blj[1, 0]
+                    jones_out[1, 1] = blj[1, 1]
         else:
             raise ex
     else:
@@ -182,7 +182,7 @@ def jones_mul_factory(have_ddes, have_coh, jones_type, accumulate):
         def jones_mul():
             pass
 
-    return njit(nogil=True, inline='always')(jones_mul)
+    return njit(nogil=True, inline="always")(jones_mul)
 
 
 def sum_coherencies_factory(have_ddes, have_coh, jones_type):
@@ -190,7 +190,7 @@ def sum_coherencies_factory(have_ddes, have_coh, jones_type):
     jones_mul = jones_mul_factory(have_ddes, have_coh, jones_type, True)
 
     if have_ddes and have_coh:
-        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, out):
+        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
             for s in range(a1j.shape[0]):
                 for r in range(time.shape[0]):
                     ti = time[r] - tmin
@@ -201,10 +201,10 @@ def sum_coherencies_factory(have_ddes, have_coh, jones_type):
                         jones_mul(a1j[s, ti, a1, f],
                                   blj[s, r, f],
                                   a2j[s, ti, a2, f],
-                                  out[r, f])
+                                  coh_out[r, f])
 
     elif have_ddes and not have_coh:
-        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, out):
+        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
             for s in range(a1j.shape[0]):
                 for r in range(time.shape[0]):
                     ti = time[r] - tmin
@@ -214,30 +214,30 @@ def sum_coherencies_factory(have_ddes, have_coh, jones_type):
                     for f in range(a1j.shape[3]):
                         jones_mul(a1j[s, ti, a1, f],
                                   a2j[s, ti, a2, f],
-                                  out[r, f])
+                                  coh_out[r, f])
 
     elif not have_ddes and have_coh:
         if jones_type == JONES_2X2:
-            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, out):
+            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
                 for s in range(blj.shape[0]):
                     for r in range(blj.shape[1]):
                         for f in range(blj.shape[2]):
                             for c1 in range(blj.shape[3]):
                                 for c2 in range(blj.shape[4]):
-                                    out[r, f, c1, c2] += blj[s, r, f, c1, c2]
+                                    coh_out[r, f, c1, c2] += blj[s, r, f, c1, c2]
         else:
-            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, out):
+            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
                 for s in range(blj.shape[0]):
                     for r in range(blj.shape[1]):
                         for f in range(blj.shape[2]):
                             for c in range(blj.shape[3]):
-                                out[r, f, c] += blj[s, r, f, c]
+                                coh_out[r, f, c] += blj[s, r, f, c]
     else:
         # noop
-        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, out):
+        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
             pass
 
-    return njit(nogil=True, inline='always')(sum_coh_fn)
+    return njit(nogil=True, inline="always")(sum_coh_fn)
 
 
 def output_factory(have_ddes, have_coh, have_dies, have_base_vis, out_dtype):
@@ -276,21 +276,21 @@ def output_factory(have_ddes, have_coh, have_dies, have_base_vis, out_dtype):
                          "for determining the output shape")
 
     # TODO(sjperkins)
-    # perhaps inline='always' on resolution of
+    # perhaps inline="always" on resolution of
     # https://github.com/numba/numba/issues/4691
     return njit(nogil=True, inline='never')(output)
 
 
 def add_coh_factory(have_bvis):
     if have_bvis:
-        def add_coh(base_vis, out):
-            out += base_vis
+        def add_coh(base_vis, add_coh_cout):
+            add_coh_cout += base_vis
     else:
         # noop
-        def add_coh(base_vis, out):
+        def add_coh(base_vis, add_coh_cout):
             pass
 
-    return njit(nogil=True, inline='always')(add_coh)
+    return njit(nogil=True, inline="always")(add_coh)
 
 
 def apply_dies_factory(have_dies, have_bvis, jones_type):
@@ -305,7 +305,7 @@ def apply_dies_factory(have_dies, have_bvis, jones_type):
     if have_dies and have_bvis:
         def apply_dies(time, ant1, ant2,
                        die1_jones, die2_jones,
-                       tmin, out):
+                       tmin, dies_out):
             # Iterate over rows
             for r in range(time.shape[0]):
                 ti = time[r] - tmin
@@ -313,14 +313,14 @@ def apply_dies_factory(have_dies, have_bvis, jones_type):
                 a2 = ant2[r]
 
                 # Iterate over channels
-                for c in range(out.shape[1]):
-                    jones_mul(die1_jones[ti, a1, c], out[r, c],
-                              die2_jones[ti, a2, c], out[r, c])
+                for c in range(dies_out.shape[1]):
+                    jones_mul(die1_jones[ti, a1, c], dies_out[r, c],
+                              die2_jones[ti, a2, c], dies_out[r, c])
 
     elif have_dies and not have_bvis:
         def apply_dies(time, ant1, ant2,
                        die1_jones, die2_jones,
-                       tmin, out):
+                       tmin, dies_out):
             # Iterate over rows
             for r in range(time.shape[0]):
                 ti = time[r] - tmin
@@ -328,18 +328,18 @@ def apply_dies_factory(have_dies, have_bvis, jones_type):
                 a2 = ant2[r]
 
                 # Iterate over channels
-                for c in range(out.shape[1]):
-                    jones_mul(die1_jones[ti, a1, c], out[r, c],
+                for c in range(dies_out.shape[1]):
+                    jones_mul(die1_jones[ti, a1, c], dies_out[r, c],
                               die2_jones[ti, a2, c],
-                              out[r, c])
+                              dies_out[r, c])
     else:
         # noop
         def apply_dies(time, ant1, ant2,
                        die1_jones, die2_jones,
-                       tmin, out):
+                       tmin, dies_out):
             pass
 
-    return njit(nogil=True, inline='always')(apply_dies)
+    return njit(nogil=True, inline="always")(apply_dies)
 
 
 def _default_none_check(arg):

--- a/africanus/rime/predict.py
+++ b/africanus/rime/predict.py
@@ -90,15 +90,15 @@ def jones_mul_factory(have_ddes, have_coh, jones_type, accumulate):
 
     if have_coh and have_ddes:
         if jones_type == JONES_1_OR_2:
-            def jones_mul(a1j, blj, a2j, jones_out):
-                for c in range(jones_out.shape[0]):
+            def jones_mul(a1j, blj, a2j, jout):
+                for c in range(jout.shape[0]):
                     if accumulate:
-                        jones_out[c] += a1j[c] * blj[c] * np.conj(a2j[c])
+                        jout[c] += a1j[c] * blj[c] * np.conj(a2j[c])
                     else:
-                        jones_out[c] = a1j[c] * blj[c] * np.conj(a2j[c])
+                        jout[c] = a1j[c] * blj[c] * np.conj(a2j[c])
 
         elif jones_type == JONES_2X2:
-            def jones_mul(a1j, blj, a2j, jones_out):
+            def jones_mul(a1j, blj, a2j, jout):
                 a2_xx_H = np.conj(a2j[0, 0])
                 a2_xy_H = np.conj(a2j[0, 1])
                 a2_yx_H = np.conj(a2j[1, 0])
@@ -110,71 +110,71 @@ def jones_mul_factory(have_ddes, have_coh, jones_type, accumulate):
                 yy = blj[1, 0] * a2_yx_H + blj[1, 1] * a2_yy_H
 
                 if accumulate:
-                    jones_out[0, 0] += a1j[0, 0] * xx + a1j[0, 1] * yx
-                    jones_out[0, 1] += a1j[0, 0] * xy + a1j[0, 1] * yy
-                    jones_out[1, 0] += a1j[1, 0] * xx + a1j[1, 1] * yx
-                    jones_out[1, 1] += a1j[1, 0] * xy + a1j[1, 1] * yy
+                    jout[0, 0] += a1j[0, 0] * xx + a1j[0, 1] * yx
+                    jout[0, 1] += a1j[0, 0] * xy + a1j[0, 1] * yy
+                    jout[1, 0] += a1j[1, 0] * xx + a1j[1, 1] * yx
+                    jout[1, 1] += a1j[1, 0] * xy + a1j[1, 1] * yy
                 else:
-                    jones_out[0, 0] = a1j[0, 0] * xx + a1j[0, 1] * yx
-                    jones_out[0, 1] = a1j[0, 0] * xy + a1j[0, 1] * yy
-                    jones_out[1, 0] = a1j[1, 0] * xx + a1j[1, 1] * yx
-                    jones_out[1, 1] = a1j[1, 0] * xy + a1j[1, 1] * yy
+                    jout[0, 0] = a1j[0, 0] * xx + a1j[0, 1] * yx
+                    jout[0, 1] = a1j[0, 0] * xy + a1j[0, 1] * yy
+                    jout[1, 0] = a1j[1, 0] * xx + a1j[1, 1] * yx
+                    jout[1, 1] = a1j[1, 0] * xy + a1j[1, 1] * yy
 
         else:
             raise ex
     elif have_ddes and not have_coh:
         if jones_type == JONES_1_OR_2:
-            def jones_mul(a1j, a2j, jones_out):
-                for c in range(jones_out.shape[0]):
+            def jones_mul(a1j, a2j, jout):
+                for c in range(jout.shape[0]):
                     if accumulate:
-                        jones_out[c] += a1j[c] * np.conj(a2j[c])
+                        jout[c] += a1j[c] * np.conj(a2j[c])
                     else:
-                        jones_out[c] = a1j[c] * np.conj(a2j[c])
+                        jout[c] = a1j[c] * np.conj(a2j[c])
 
         elif jones_type == JONES_2X2:
-            def jones_mul(a1j, a2j, jones_out):
+            def jones_mul(a1j, a2j, jout):
                 a2_xx_H = np.conj(a2j[0, 0])
                 a2_xy_H = np.conj(a2j[0, 1])
                 a2_yx_H = np.conj(a2j[1, 0])
                 a2_yy_H = np.conj(a2j[1, 1])
 
                 if accumulate:
-                    jones_out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
-                    jones_out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
-                    jones_out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
-                    jones_out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
+                    jout[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
+                    jout[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
+                    jout[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
+                    jout[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
                 else:
-                    jones_out[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
-                    jones_out[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
-                    jones_out[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
-                    jones_out[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
+                    jout[0, 0] += a1j[0, 0] * a2_xx_H + a1j[0, 1] * a2_xy_H
+                    jout[0, 1] += a1j[0, 0] * a2_yx_H + a1j[0, 1] * a2_yy_H
+                    jout[1, 0] += a1j[1, 0] * a2_xx_H + a1j[1, 1] * a2_xy_H
+                    jout[1, 1] += a1j[1, 0] * a2_yx_H + a1j[1, 1] * a2_yy_H
         else:
             raise ex
     elif not have_ddes and have_coh:
         if jones_type == JONES_1_OR_2:
-            def jones_mul(blj, jones_out):
-                for c in range(jones_out.shape[0]):
+            def jones_mul(blj, jout):
+                for c in range(jout.shape[0]):
                     if accumulate:
-                        jones_out[c] += blj[c]
-                    elif id(blj) == id(jones_out):
+                        jout[c] += blj[c]
+                    elif id(blj) == id(jout):
                         pass
                     else:
-                        jones_out[c] = blj[c]
+                        jout[c] = blj[c]
 
         elif jones_type == JONES_2X2:
-            def jones_mul(blj, jones_out):
+            def jones_mul(blj, jout):
                 if accumulate:
-                    jones_out[0, 0] += blj[0, 0]
-                    jones_out[0, 1] += blj[0, 1]
-                    jones_out[1, 0] += blj[1, 0]
-                    jones_out[1, 1] += blj[1, 1]
-                elif id(blj) == id(jones_out):
+                    jout[0, 0] += blj[0, 0]
+                    jout[0, 1] += blj[0, 1]
+                    jout[1, 0] += blj[1, 0]
+                    jout[1, 1] += blj[1, 1]
+                elif id(blj) == id(jout):
                     pass
                 else:
-                    jones_out[0, 0] = blj[0, 0]
-                    jones_out[0, 1] = blj[0, 1]
-                    jones_out[1, 0] = blj[1, 0]
-                    jones_out[1, 1] = blj[1, 1]
+                    jout[0, 0] = blj[0, 0]
+                    jout[0, 1] = blj[0, 1]
+                    jout[1, 0] = blj[1, 0]
+                    jout[1, 1] = blj[1, 1]
         else:
             raise ex
     else:
@@ -190,7 +190,7 @@ def sum_coherencies_factory(have_ddes, have_coh, jones_type):
     jones_mul = jones_mul_factory(have_ddes, have_coh, jones_type, True)
 
     if have_ddes and have_coh:
-        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
+        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, cout):
             for s in range(a1j.shape[0]):
                 for r in range(time.shape[0]):
                     ti = time[r] - tmin
@@ -201,10 +201,10 @@ def sum_coherencies_factory(have_ddes, have_coh, jones_type):
                         jones_mul(a1j[s, ti, a1, f],
                                   blj[s, r, f],
                                   a2j[s, ti, a2, f],
-                                  coh_out[r, f])
+                                  cout[r, f])
 
     elif have_ddes and not have_coh:
-        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
+        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, cout):
             for s in range(a1j.shape[0]):
                 for r in range(time.shape[0]):
                     ti = time[r] - tmin
@@ -214,27 +214,27 @@ def sum_coherencies_factory(have_ddes, have_coh, jones_type):
                     for f in range(a1j.shape[3]):
                         jones_mul(a1j[s, ti, a1, f],
                                   a2j[s, ti, a2, f],
-                                  coh_out[r, f])
+                                  cout[r, f])
 
     elif not have_ddes and have_coh:
         if jones_type == JONES_2X2:
-            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
+            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, cout):
                 for s in range(blj.shape[0]):
                     for r in range(blj.shape[1]):
                         for f in range(blj.shape[2]):
                             for c1 in range(blj.shape[3]):
                                 for c2 in range(blj.shape[4]):
-                                    coh_out[r, f, c1, c2] += blj[s, r, f, c1, c2]
+                                    cout[r, f, c1, c2] += blj[s, r, f, c1, c2]
         else:
-            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
+            def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, cout):
                 for s in range(blj.shape[0]):
                     for r in range(blj.shape[1]):
                         for f in range(blj.shape[2]):
                             for c in range(blj.shape[3]):
-                                coh_out[r, f, c] += blj[s, r, f, c]
+                                cout[r, f, c] += blj[s, r, f, c]
     else:
         # noop
-        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, coh_out):
+        def sum_coh_fn(time, ant1, ant2, a1j, blj, a2j, tmin, cout):
             pass
 
     return njit(nogil=True, inline="always")(sum_coh_fn)

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ if not on_rtd:
         # astropy breaks with numpy 1.15.3
         # https://github.com/astropy/astropy/issues/7943
         "numpy >= 1.14.0, != 1.15.3",
-        "numba >= 0.52; python_version < '3.9'",
-        "numba >= 0.53.1; python_version >= '3.9'",
+        "numba >= 0.53.1, != 0.54.0"
     ]
 
 extras_require = {


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
