### PR TITLE
Use contextlib.suppress instead of dask.utils.ignoring in EstimatingProgressBar

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.11 (YYYY-MM-DD)
 -------------------
+* Using `contextlib.suppress` instead of deprecated `dask.util.ignoring` in EstimatingProgressBar (:pr:`256`)
 * Disallow numba 0.54.0 (:pr:`254`)
 * Upgrade to CuPy 9.0 and fix template encoding (:pr:`251`)
 * Parse and zero spectral models containing 'nan' and 'inf' in wsclean model files (:pr:`250`)

--- a/africanus/util/dask_util.py
+++ b/africanus/util/dask_util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
+from contextlib import suppress
 from timeit import default_timer
 from threading import Event, Thread, Lock
 import os
@@ -8,7 +9,6 @@ import sys
 
 try:
     from dask.callbacks import Callback
-    from dask.utils import ignoring
 except ImportError as e:
     opt_import_err = e
     Callback = object
@@ -119,7 +119,7 @@ def update_bar(elapsed, prev_completed, prev_estimated, pb):
                 format_time(elapsed),
                 "???" if estimated == 0.0 else format_time(estimated))
 
-    with ignoring(ValueError):
+    with suppress(ValueError):
         pb._file.write(msg)
         pb._file.flush()
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
