### PR TITLE
Handle empty spectral indices in the WSClean Model

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.3.1 (2021-09-09)
+------------------
+* Handle empty spectral indices in WSClean Model (:pr:`258`)
+
 0.3.0 (2021-09-09)
 ------------------
 * Deprecate Python 3.6 support, add Python 3.9 support (:pr:`248`)

--- a/africanus/model/wsclean/file_model.py
+++ b/africanus/model/wsclean/file_model.py
@@ -55,7 +55,12 @@ def arcsec2rad(arcseconds=0.0):
 
 
 def spi_converter(spi):
-    return [float(c) for c in spi.strip("[] ").split(",")]
+    spi = spi.strip("[] ")
+
+    if not spi:
+        return []
+
+    return [float(c) for c in spi.split(",")]
 
 
 _COLUMN_CONVERTERS = {


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
