### PR TITLE
Fix visibilities typo in monolithic BDA function

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,12 +2,16 @@
 History
 =======
 
-0.3.1 (2021-09-09)
+X.Y.Z (YYYY-MM-DD)
 ------------------
 * Restrict numba version to <= 0.54.0 (:pr:`259`)
+* BDA fix typos in numba wrapper (:pr:`261`)
+* BDA Time-smearing fixes (:pr:`253`)
+
+0.3.1 (2021-09-09)
+------------------
 * Handle empty spectral indices in WSClean Model (:pr:`258`)
 * Support missing data during BDA (:pr:`252`)
-* BDA Time-smearing fixes (:pr:`253`)
 
 0.3.0 (2021-09-09)
 ------------------

--- a/africanus/averaging/bda_avg.py
+++ b/africanus/averaging/bda_avg.py
@@ -588,7 +588,7 @@ def bda(time, interval, antenna1, antenna2,
                              # None,  # chan_data.chan_width,
                              # None,  # chan_data.effective_bw,
                              # None,  # chan_data.resolution,
-                             row_chan_avg.visibilites,
+                             row_chan_avg.visibilities,
                              row_chan_avg.flag,
                              row_chan_avg.weight_spectrum,
                              row_chan_avg.sigma_spectrum)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
